### PR TITLE
brief-04: join flow (current player + seats)

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -14,10 +14,12 @@
       <a href="/admin.html">Admin</a>
     </nav>
 
-    <!-- PLAYERS (kept from previous briefs) -->
+    <div id="you"></div>
+
+    <!-- PLAYERS -->
     <div class="card">
       <h1>Admin — Players</h1>
-      <p class="small">Add a player. Each new player starts with $1,000.00 (walletCents = 100000).</p>
+      <p class="small">Add a player. Each new player starts with $1,000.00.</p>
 
       <div style="display:flex; gap:8px; align-items:center; margin:12px 0;">
         <input id="player-name" placeholder="Player name" style="padding:10px;border-radius:10px;border:1px solid #334155;background:#0b1220;color:#e5e7eb;flex:1" />
@@ -33,10 +35,10 @@
       <div id="players-list" class="small">Loading players…</div>
     </div>
 
-    <!-- TABLES (new) -->
+    <!-- TABLES -->
     <div class="card" style="margin-top:16px;">
       <h1 style="margin-top:0;">Admin — Tables</h1>
-      <p class="small">Create a table with defaults. Fields are in dollars; we’ll store cents in Firestore.</p>
+      <p class="small">Create a table with defaults. Fields are in dollars; we store cents.</p>
 
       <div style="display:grid;grid-template-columns:1fr 1fr;gap:10px;margin:12px 0;">
         <input id="table-name" placeholder="Table name (e.g., Family Table)" style="padding:10px;border-radius:10px;border:1px solid #334155;background:#0b1220;color:#e5e7eb;grid-column:1/-1" />
@@ -69,31 +71,17 @@
     </div>
   </div>
 
-  <!-- Firebase init -->
   <script type="module" src="/firebase-init.js"></script>
-
-  <!-- Firestore logic for Players + Tables -->
   <script type="module">
-    import { app } from "/firebase-init.js";
+    import { db, dollars, parseDollarsToCents, renderCurrentPlayerControls } from "/common.js";
     import {
-      getFirestore, collection, addDoc, serverTimestamp,
-      query, orderBy, onSnapshot, doc, updateDoc, deleteDoc
+      collection, addDoc, serverTimestamp, query, orderBy, onSnapshot,
+      doc, updateDoc, deleteDoc
     } from "https://www.gstatic.com/firebasejs/10.12.5/firebase-firestore.js";
 
-    const db = getFirestore(app);
+    renderCurrentPlayerControls("you");
 
-    // ---------- helpers ----------
-    const dollars = (cents) =>
-      `$${(cents/100).toLocaleString(undefined,{minimumFractionDigits:2, maximumFractionDigits:2})}`;
-    const parseDollarsToCents = (input) => {
-      const clean = String(input).replace(/[^0-9.]/g, "");
-      if (!clean) return null;
-      const value = Number(clean);
-      if (Number.isNaN(value)) return null;
-      return Math.max(0, Math.round(value * 100));
-    };
-
-    // ---------- PLAYERS (add/list/edit/delete) ----------
+    // ----- players (same behavior as before) -----
     const playersCol = collection(db, "players");
     const addBtn = document.getElementById("add-player");
     const nameInput = document.getElementById("player-name");
@@ -111,9 +99,7 @@
         nameInput.value = ""; nameInput.focus();
       } catch (err) {
         statusEl.textContent = "Error: " + (err?.message || err);
-      } finally {
-        addBtn.disabled = false;
-      }
+      } finally { addBtn.disabled = false; }
     });
 
     const renderPlayerRow = (id, d) => {
@@ -145,8 +131,7 @@
     });
 
     listEl?.addEventListener("click", async (e) => {
-      const row = e.target.closest(".row");
-      if (!row || row.getAttribute("data-type") !== "player") return;
+      const row = e.target.closest(".row"); if (!row || row.getAttribute("data-type") !== "player") return;
       const id = row.getAttribute("data-id");
       const status = row.querySelector(".row-status");
 
@@ -160,14 +145,14 @@
       }
 
       if (e.target.classList.contains("delete-btn")) {
-        const ok = confirm("Delete this player? This cannot be undone."); if (!ok) return;
+        const ok = confirm("Delete this player?"); if (!ok) return;
         status.textContent = "Deleting…";
-        try { await deleteDoc(doc(db, "players", id)); }
+        try { await deleteDoc(doc(db, "players", id)); } 
         catch (err) { status.textContent = "Error: " + (err?.message || err); }
       }
     });
 
-    // ---------- TABLES (create/list + archive toggle) ----------
+    // ----- tables (same as before) -----
     const tablesCol = collection(db, "tables");
     const tName = document.getElementById("table-name");
     const tMin = document.getElementById("min-buyin");
@@ -178,6 +163,33 @@
     const tBtn = document.getElementById("create-table");
     const tStatus = document.getElementById("table-status");
     const tList = document.getElementById("tables-list");
+
+    tBtn?.addEventListener("click", async () => {
+      const name = (tName.value || "").trim();
+      const minC = parseDollarsToCents(tMin.value);
+      const defC = parseDollarsToCents(tDef.value);
+      const maxC = parseDollarsToCents(tMax.value);
+      const sbC  = parseDollarsToCents(tSB.value);
+      const bbC  = parseDollarsToCents(tBB.value);
+
+      const err = (m) => (tStatus.textContent = m);
+
+      if (!name) return err("Enter a table name.");
+      if ([minC, defC, maxC, sbC, bbC].some(v => v === null)) return err("Enter valid numbers.");
+      if (minC > maxC) return err("Min buy-in > max.");
+      if (defC < minC || defC > maxC) return err("Default must be between min and max.");
+      if (sbC <= 0 || bbC <= 0) return err("Blinds must be > 0.");
+
+      tStatus.textContent = "Creating…"; tBtn.disabled = true;
+      try {
+        await addDoc(tablesCol, {
+          name, minBuyInCents: minC, maxBuyInCents: maxC, defaultBuyInCents: defC,
+          smallBlindCents: sbC, bigBlindCents: bbC, active: true, createdAt: serverTimestamp()
+        });
+        tStatus.textContent = "Table created ✔"; tName.value = "";
+      } catch (e) { tStatus.textContent = "Error: " + (e?.message || e); }
+      finally { tBtn.disabled = false; }
+    });
 
     const renderTableRow = (id, d) => {
       const blindStr = `${dollars(d.smallBlindCents || 0)}/${dollars(d.bigBlindCents || 0)}`;
@@ -200,46 +212,7 @@
       `;
     };
 
-    tBtn?.addEventListener("click", async () => {
-      const name = (tName.value || "").trim();
-      const minC = parseDollarsToCents(tMin.value);
-      const defC = parseDollarsToCents(tDef.value);
-      const maxC = parseDollarsToCents(tMax.value);
-      const sbC  = parseDollarsToCents(tSB.value);
-      const bbC  = parseDollarsToCents(tBB.value);
-
-      const err = (msg) => { tStatus.textContent = msg; return false; };
-
-      if (!name) return err("Please enter a table name.");
-      if ([minC, defC, maxC, sbC, bbC].some(v => v === null)) return err("Enter valid numbers for all fields.");
-      if (minC > maxC) return err("Min buy-in cannot be greater than max.");
-      if (defC < minC || defC > maxC) return err("Default buy-in must be between min and max.");
-      if (sbC <= 0 || bbC <= 0) return err("Blinds must be greater than zero.");
-
-      tStatus.textContent = "Creating…";
-      tBtn.disabled = true;
-      try {
-        await addDoc(tablesCol, {
-          name,
-          minBuyInCents: minC,
-          maxBuyInCents: maxC,
-          defaultBuyInCents: defC,
-          smallBlindCents: sbC,
-          bigBlindCents: bbC,
-          active: true,
-          createdAt: serverTimestamp()
-        });
-        tStatus.textContent = "Table created ✔";
-        tName.value = "";
-      } catch (e) {
-        tStatus.textContent = "Error: " + (e?.message || e);
-      } finally {
-        tBtn.disabled = false;
-      }
-    });
-
-    const tablesQ = query(tablesCol, orderBy("createdAt", "desc"));
-    onSnapshot(tablesQ, (snap) => {
+    onSnapshot(query(tablesCol, orderBy("createdAt", "desc")), (snap) => {
       if (!tList) return;
       if (snap.empty) { tList.textContent = "No tables yet."; return; }
       const rows = [];
@@ -247,7 +220,6 @@
       tList.innerHTML = rows.join("");
     });
 
-    // toggle active/archive
     document.addEventListener("click", async (e) => {
       const row = e.target.closest(".row");
       if (!row || row.getAttribute("data-type") !== "table") return;
@@ -257,8 +229,8 @@
       if (e.target.classList.contains("toggle-active-btn")) {
         status.textContent = "Updating…";
         try {
-          // read current label to infer new state
-          const toArchive = e.target.textContent.includes("Archive");
+          const label = e.target.textContent;
+          const toArchive = label.includes("Archive");
           await updateDoc(doc(db, "tables", id), { active: !toArchive });
           status.textContent = "Updated ✔";
         } catch (err) {
@@ -266,6 +238,8 @@
         }
       }
     });
+
+    // Render the “You” card
   </script>
 </body>
 </html>

--- a/public/common.js
+++ b/public/common.js
@@ -1,0 +1,101 @@
+//// Common helpers + “Current Player” UI (ESM)
+import { app } from "/firebase-init.js";
+import {
+  getFirestore, collection, query, orderBy, onSnapshot,
+  doc, onSnapshot as onDoc
+} from "https://www.gstatic.com/firebasejs/10.12.5/firebase-firestore.js";
+
+export const db = getFirestore(app);
+
+export const dollars = (cents) =>
+  `$${(cents/100).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+
+export const parseDollarsToCents = (input) => {
+  const clean = String(input).replace(/[^0-9.]/g, "");
+  if (!clean) return null;
+  const value = Number(clean);
+  if (Number.isNaN(value)) return null;
+  return Math.max(0, Math.round(value * 100));
+};
+
+const LS_KEY_ID = "currentPlayerId";
+const LS_KEY_NAME = "currentPlayerName";
+
+export const getCurrentPlayer = () => {
+  const id = localStorage.getItem(LS_KEY_ID);
+  const name = localStorage.getItem(LS_KEY_NAME);
+  return id ? { id, name: name || "" } : null;
+};
+
+export function renderCurrentPlayerControls(containerId) {
+  const root = document.getElementById(containerId);
+  if (!root) return;
+
+  root.innerHTML = `
+    <div class="card">
+      <h2 style="margin-top:0;">You</h2>
+      <div style="display:flex; gap:8px; align-items:center; flex-wrap:wrap;">
+        <label class="small">Current player
+          <select id="cp-select" style="margin-left:8px;padding:8px;border-radius:10px;border:1px solid #334155;background:#0b1220;color:#e5e7eb"></select>
+        </label>
+        <span id="cp-wallet" class="small" style="margin-left:12px;">Wallet: —</span>
+      </div>
+      <div id="cp-note" class="small" style="margin-top:6px;opacity:.8;">Select who you are before joining a table.</div>
+    </div>
+  `;
+
+  const select = root.querySelector("#cp-select");
+  const walletEl = root.querySelector("#cp-wallet");
+
+  // Populate players dropdown (live)
+  const playersCol = collection(db, "players");
+  const qPlayers = query(playersCol, orderBy("createdAt", "desc"));
+  let unsubPlayerDoc = null;
+
+  onSnapshot(qPlayers, (snap) => {
+    const current = getCurrentPlayer();
+    const options = [];
+    snap.forEach((docSnap) => {
+      const d = docSnap.data();
+      const id = docSnap.id;
+      const name = d.name || "(no name)";
+      const selected = current && current.id === id ? "selected" : "";
+      options.push(`<option value="${id}" ${selected}>${name}</option>`);
+    });
+    select.innerHTML = options.join("") || `<option value="">(no players yet)</option>`;
+
+    // If nothing selected but we have players, pick first
+    if (!getCurrentPlayer() && snap.size > 0) {
+      const first = snap.docs[0];
+      localStorage.setItem(LS_KEY_ID, first.id);
+      localStorage.setItem(LS_KEY_NAME, first.data().name || "");
+      select.value = first.id;
+      attachWalletListener(first.id);
+    } else if (getCurrentPlayer()) {
+      attachWalletListener(getCurrentPlayer().id);
+    }
+  });
+
+  select.addEventListener("change", () => {
+    const id = select.value;
+    const name = select.options[select.selectedIndex]?.text || "";
+    localStorage.setItem(LS_KEY_ID, id);
+    localStorage.setItem(LS_KEY_NAME, name);
+    attachWalletListener(id);
+  });
+
+  function attachWalletListener(playerId) {
+    if (unsubPlayerDoc) unsubPlayerDoc();
+    if (!playerId) {
+      walletEl.textContent = "Wallet: —";
+      return;
+    }
+    const ref = doc(db, "players", playerId);
+    unsubPlayerDoc = onDoc(ref, (snap) => {
+      const d = snap.data();
+      const w = typeof d?.walletCents === "number" ? dollars(d.walletCents) : "$0.00";
+      walletEl.textContent = `Wallet: ${w}`;
+    });
+  }
+}
+

--- a/public/lobby.html
+++ b/public/lobby.html
@@ -14,50 +14,187 @@
       <a href="/admin.html">Admin</a>
     </nav>
 
-    <div class="card">
+    <div id="you"></div>
+
+    <div class="card" style="margin-top:16px;">
       <h1>Lobby</h1>
-      <p class="small">Showing ACTIVE tables. (Join flow coming soon.)</p>
+      <p class="small">Join a table as the selected player. Your buy-in must be between min/max and ≤ your wallet.</p>
       <div id="tables" class="small">Loading tables…</div>
     </div>
   </div>
 
   <script type="module" src="/firebase-init.js"></script>
   <script type="module">
-    import { app } from "/firebase-init.js";
+    import { db, dollars, parseDollarsToCents, getCurrentPlayer, renderCurrentPlayerControls } from "/common.js";
     import {
-      getFirestore, collection, query, orderBy, onSnapshot
+      collection, query, orderBy, onSnapshot, doc, collection as subcol,
+      runTransaction, serverTimestamp, getDoc
     } from "https://www.gstatic.com/firebasejs/10.12.5/firebase-firestore.js";
 
-    const db = getFirestore(app);
+    renderCurrentPlayerControls("you");
+
     const tablesCol = collection(db, "tables");
     const listEl = document.getElementById("tables");
 
-    const dollars = (cents) =>
-      `$${(cents/100).toLocaleString(undefined,{minimumFractionDigits:2, maximumFractionDigits:2})}`;
-
-    const renderCard = (d) => {
+    const renderTable = (id, d, seatsHtml) => {
       const blindStr = `${dollars(d.smallBlindCents || 0)}/${dollars(d.bigBlindCents || 0)}`;
       const rangeStr = `${dollars(d.minBuyInCents || 0)}–${dollars(d.maxBuyInCents || 0)} (default ${dollars(d.defaultBuyInCents || 0)})`;
       return `
         <div style="margin-top:12px;padding:14px;border:1px solid #334155;border-radius:12px;background:#111827">
-          <div style="font-weight:700">${d.name || "(no name)"}</div>
-          <div class="small">Blinds: ${blindStr}</div>
-          <div class="small">Buy-in: ${rangeStr}</div>
-          <div style="margin-top:8px;">
-            <button disabled title="Join flow coming soon" style="opacity:.6;cursor:not-allowed;padding:8px 12px;border-radius:10px;border:1px solid #334155;background:#0ea5e9;color:white;font-weight:700;">Join (coming soon)</button>
+          <div style="display:flex;justify-content:space-between;gap:12px;align-items:center;">
+            <div>
+              <div style="font-weight:700">${d.name || "(no name)"}</div>
+              <div class="small">Blinds: ${blindStr}</div>
+              <div class="small">Buy-in: ${rangeStr}</div>
+            </div>
+            <div>
+              <button class="join-btn" data-id="${id}" style="padding:8px 12px;border-radius:10px;border:1px solid #334155;background:#0ea5e9;color:white;font-weight:700;">Join</button>
+              <button class="leave-btn" data-id="${id}" style="padding:8px 12px;border-radius:10px;border:1px solid #334155;background:#ef4444;color:white;font-weight:700;">Leave</button>
+            </div>
+          </div>
+          <div class="small" style="margin-top:8px;">Seated:</div>
+          <div>${seatsHtml || "(none yet)"}</div>
+          <div class="join-panel" id="join-${id}" style="display:none;margin-top:10px;">
+            <div class="small">Choose your buy-in (min–max):</div>
+            <input id="amount-${id}" type="number" step="0.01" style="width:160px;padding:8px;border-radius:10px;border:1px solid #334155;background:#0b1220;color:#e5e7eb" />
+            <button class="confirm-join" data-id="${id}" style="padding:8px 12px;border-radius:10px;border:1px solid #334155;background:#22c55e;color:#052e13;font-weight:700;">Confirm</button>
+            <span class="join-status small" id="status-${id}" style="margin-left:8px;"></span>
           </div>
         </div>
       `;
     };
 
-    const q = query(tablesCol, orderBy("createdAt", "desc"));
-    onSnapshot(q, (snap) => {
-      const rows = [];
+    // Fetch tables and wire seats listeners
+    const seatUnsubs = new Map();
+    onSnapshot(query(tablesCol, orderBy("createdAt", "desc")), (snap) => {
+      const blocks = [];
+      // unsubscribe previous seat listeners
+      seatUnsubs.forEach(unsub => unsub());
+      seatUnsubs.clear();
+
       snap.forEach(docSnap => {
+        const id = docSnap.id;
         const d = docSnap.data();
-        if (d.active) rows.push(renderCard(d));
+        if (!d.active) return;
+
+        // placeholder; will update once seats load
+        blocks.push({ id, html: renderTable(id, d, "Loading…"), data: d });
+
+        // live seats under each table
+        const seatsRef = subcol(doc(db, "tables", id), "seats");
+        const unsub = onSnapshot(seatsRef, (seatSnap) => {
+          const seated = [];
+          seatSnap.forEach(s => {
+            const sd = s.data();
+            seated.push(`<div style="display:flex;justify-content:space-between;"><span>${sd.playerName || sd.playerId}</span><span>${dollars(sd.chipStackCents || 0)}</span></div>`);
+          });
+          // re-render the specific block
+          const idx = blocks.findIndex(b => b.id === id);
+          if (idx >= 0) {
+            blocks[idx].html = renderTable(id, blocks[idx].data, seated.join("") || "(none yet)");
+            listEl.innerHTML = blocks.map(b => b.html).join("");
+          }
+        });
+        seatUnsubs.set(id, unsub);
       });
-      listEl.innerHTML = rows.length ? rows.join("") : "No active tables.";
+
+      listEl.innerHTML = blocks.length ? blocks.map(b => b.html).join("") : "No active tables.";
+    });
+
+    // Click handlers (join/leave)
+    document.addEventListener("click", async (e) => {
+      const joinBtn = e.target.closest(".join-btn");
+      const leaveBtn = e.target.closest(".leave-btn");
+      const confirmBtn = e.target.closest(".confirm-join");
+      const cp = getCurrentPlayer();
+
+      if (joinBtn) {
+        const id = joinBtn.getAttribute("data-id");
+        const panel = document.getElementById(`join-${id}`);
+        // prefill default from table
+        const tableSnap = await getDoc(doc(db, "tables", id));
+        const t = tableSnap.data();
+        const input = document.getElementById(`amount-${id}`);
+        input.value = (t?.defaultBuyInCents ? (t.defaultBuyInCents/100).toFixed(2) : "0.00");
+        panel.style.display = "block";
+        return;
+      }
+
+      if (confirmBtn) {
+        if (!cp) { alert("Select a Current Player first."); return; }
+        const tableId = confirmBtn.getAttribute("data-id");
+        const status = document.getElementById(`status-${tableId}`);
+        status.textContent = "Joining…";
+
+        try {
+          await runTransaction(db, async (tx) => {
+            const tableRef = doc(db, "tables", tableId);
+            const playerRef = doc(db, "players", cp.id);
+            const seatRef = doc(db, "tables", tableId, "seats", cp.id);
+
+            const [tableSnap, playerSnap, seatSnap] = await Promise.all([
+              tx.get(tableRef), tx.get(playerRef), tx.get(seatRef)
+            ]);
+            if (!tableSnap.exists()) throw new Error("Table not found.");
+            if (!playerSnap.exists()) throw new Error("Player not found.");
+
+            const t = tableSnap.data();
+            const p = playerSnap.data();
+            const amountCents = parseDollarsToCents(document.getElementById(`amount-${tableId}`).value);
+            if (amountCents === null) throw new Error("Enter a valid amount.");
+
+            if (amountCents < (t.minBuyInCents||0) || amountCents > (t.maxBuyInCents||0))
+              throw new Error("Amount must be between min and max buy-in.");
+            if ((p.walletCents||0) < amountCents)
+              throw new Error("Not enough wallet balance.");
+            if (seatSnap.exists())
+              throw new Error("You are already seated at this table.");
+
+            // deduct wallet, create seat
+            tx.update(playerRef, { walletCents: (p.walletCents||0) - amountCents });
+            tx.set(seatRef, {
+              playerId: cp.id,
+              playerName: cp.name || p.name || "",
+              chipStackCents: amountCents,
+              satAt: serverTimestamp(),
+              active: true
+            });
+          });
+          status.textContent = "Joined ✔";
+        } catch (err) {
+          status.textContent = "Error: " + (err?.message || err);
+        }
+        return;
+      }
+
+      if (leaveBtn) {
+        if (!cp) { alert("Select a Current Player first."); return; }
+        const tableId = leaveBtn.getAttribute("data-id");
+
+        const ok = confirm("Leave this table and return remaining chips to your wallet?");
+        if (!ok) return;
+
+        try {
+          await runTransaction(db, async (tx) => {
+            const playerRef = doc(db, "players", cp.id);
+            const seatRef = doc(db, "tables", tableId, "seats", cp.id);
+
+            const [playerSnap, seatSnap] = await Promise.all([tx.get(playerRef), tx.get(seatRef)]);
+            if (!seatSnap.exists()) throw new Error("You are not seated here.");
+
+            const p = playerSnap.data() || {};
+            const s = seatSnap.data();
+            const newWallet = (p.walletCents || 0) + (s.chipStackCents || 0);
+
+            tx.update(playerRef, { walletCents: newWallet });
+            tx.delete(seatRef);
+          });
+          alert("You left the table. Chips returned to wallet.");
+        } catch (err) {
+          alert("Error: " + (err?.message || err));
+        }
+        return;
+      }
     });
   </script>
 </body>


### PR DESCRIPTION
## Summary
- extract common helpers and "Current Player" dropdown with live wallet balance
- allow joining/leaving tables with wallet checks and seat creation via transactions
- admin + lobby now share current player controls

## Testing
- `npm test` *(fails: Could not read package.json)*

Firebase Hosting Preview: _(pending automatic build)_

------
https://chatgpt.com/codex/tasks/task_e_68c36835e5f4832e83c14d9b213ce4de