### PR TITLE
brief-06e: fix functions predeploy

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -7,7 +7,7 @@
   "functions": {
     "source": "functions",
     "predeploy": [
-      "npm --prefix \"$RESOURCE_DIR\" ci",
+      "npm --prefix \"$RESOURCE_DIR\" install --no-audit --no-fund",
       "npm --prefix \"$RESOURCE_DIR\" run build"
     ]
   },


### PR DESCRIPTION
## Summary
- use `npm install --no-audit --no-fund` instead of `npm ci` in Functions predeploy step

## Testing
- `npm --prefix functions install --no-audit --no-fund`
- `npm --prefix functions run build`


------
https://chatgpt.com/codex/tasks/task_e_68c47e74016c832e91f5dd1a95a7c326