### PR TITLE
brief-06f: CI deploy stability (--force)

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -20,4 +20,4 @@ jobs:
       - name: Install Firebase CLI
         run: npm i -g firebase-tools
       - name: Deploy Functions + Hosting
-        run: firebase deploy --only functions,hosting --project jam-poker --non-interactive
+        run: firebase deploy --only functions,hosting --project jam-poker --non-interactive --force


### PR DESCRIPTION
## Summary
- use `--force` in Firebase deploy step to ensure artifacts cleanup policy doesn't cause failure

## Testing
- `npm test` (fails: Could not read package.json)
- `cd functions && npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68c48e072ab4832e93acdf989a834254