### PR TITLE
brief-10: preflop betting skeleton (intents + turn order)

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -32,5 +32,16 @@ service cloud.firestore {
       allow read: if true;
       allow write: if false;
     }
+
+    match /tables/{tableId}/hands/{handId}/intents/{intentId} {
+      allow read: if true;
+      allow create: if request.resource.data.keys().hasOnly(
+            ['playerId', 'type', 'amountCents', 'createdAt']) &&
+          request.resource.data.playerId is string &&
+          request.resource.data.type in ['fold', 'check', 'call', 'raise'] &&
+          (request.resource.data.amountCents == null ||
+            request.resource.data.amountCents is number);
+      allow update, delete: if false;
+    }
   }
 }

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -60,6 +60,38 @@ function rotateDealer(seats: SeatInfo[], currentDealerId: string): string {
   return seats[(idx + 1) % seats.length].playerId;
 }
 
+function nextSeat(
+  seats: SeatInfo[],
+  startSeatNum: number,
+  folded: Record<string, true>
+): number {
+  const count = seats.length;
+  for (let i = 1; i <= count; i++) {
+    const seat = seats[(startSeatNum + i) % count];
+    if (!seat) continue;
+    if (folded[seat.playerId]) continue;
+    if (seat.chipStackCents <= 0) continue;
+    return seat.seatNum;
+  }
+  return startSeatNum;
+}
+
+function highestContribution(contrib: Record<string, number> = {}): number {
+  return Object.values(contrib).reduce((m, v) => (v > m ? v : m), 0);
+}
+
+function toCallFor(contrib: Record<string, number>, playerId: string): number {
+  const highest = highestContribution(contrib);
+  const cur = contrib[playerId] || 0;
+  return Math.max(0, highest - cur);
+}
+
+function minRaiseFrom(hand: any, bb: number): number {
+  return hand.lastAggressorSeatNum != null && typeof hand.minRaiseCents === "number"
+    ? hand.minRaiseCents
+    : bb;
+}
+
 async function createHandTx(tx: Transaction, tableRef: DocumentReference, data: any) {
   const handRef = tableRef.collection("hands").doc();
   tx.set(handRef, data);
@@ -159,7 +191,178 @@ export const onHandCreated = onDocumentCreated(
         },
         contributions,
         potCents: sbAmount + bbAmount,
+        stage: "preflop",
+        lastAggressorSeatNum: bbSeat.seatNum,
+        actorSeatNum:
+          seats.length === 2
+            ? dealerSeat.seatNum
+            : (bbSeat.seatNum + 1) % seats.length,
+        folded: {},
       });
+
+      const actorSeatNum =
+        seats.length === 2
+          ? dealerSeat.seatNum
+          : (bbSeat.seatNum + 1) % seats.length;
+      const actorPlayerId = seats.find((s) => s.seatNum === actorSeatNum)?.playerId || "";
+      const toCallCents = toCallFor(contributions, actorPlayerId);
+      const minRaiseCents = minRaiseFrom({ lastAggressorSeatNum: bbSeat.seatNum }, table.bigBlindCents);
+      tx.update(handRef, { toCallCents, minRaiseCents });
+    });
+  }
+);
+
+// Trigger: player action intents
+export const onIntentCreated = onDocumentCreated(
+  { region: "us-central1", document: "tables/{tableId}/hands/{handId}/intents/{intentId}" },
+  async (event) => {
+    const { tableId, handId, intentId } = event.params;
+    const tableRef = db.collection("tables").doc(tableId);
+    const handRef = tableRef.collection("hands").doc(handId);
+    const intentRef = handRef.collection("intents").doc(intentId);
+
+    await db.runTransaction(async (tx) => {
+      const [tableSnap, handSnap, intentSnap] = await Promise.all([
+        tx.get(tableRef),
+        tx.get(handRef),
+        tx.get(intentRef),
+      ]);
+      if (!tableSnap.exists || !handSnap.exists || !intentSnap.exists) return;
+      const hand = handSnap.data() as any;
+      const intent = intentSnap.data() as any;
+
+      if (hand.status !== "pending" || hand.stage !== "preflop") {
+        tx.delete(intentRef);
+        return;
+      }
+
+      const seats = await getActiveSeats(tx, tableRef);
+      const folded: Record<string, true> = hand.folded || {};
+      const seatByNum: Record<number, SeatInfo> = {};
+      seats.forEach((s) => (seatByNum[s.seatNum] = s));
+      const seat = seats.find((s) => s.playerId === intent.playerId);
+      if (!seat || seat.seatNum !== hand.actorSeatNum || folded[intent.playerId]) {
+        tx.delete(intentRef);
+        return;
+      }
+      if (seat.chipStackCents <= 0) {
+        tx.delete(intentRef);
+        return;
+      }
+
+      const contributions: Record<string, number> = hand.contributions || {};
+      const toCall = toCallFor(contributions, intent.playerId);
+      let pot = hand.potCents || 0;
+      let actorSeatNum = hand.actorSeatNum;
+      let lastAggressorSeatNum = hand.lastAggressorSeatNum;
+      let minRaiseCents = hand.minRaiseCents;
+
+      const updateSeat = (playerId: string, newChips: number) => {
+        tx.update(tableRef.collection("seats").doc(playerId), {
+          chipStackCents: newChips,
+        });
+      };
+
+      const next = () => {
+        const ns = nextSeat(seats, actorSeatNum, folded);
+        const nextSeatInfo = seatByNum[ns];
+        if (
+          nextSeatInfo &&
+          ns === lastAggressorSeatNum &&
+          toCallFor(contributions, nextSeatInfo.playerId) === 0
+        ) {
+          tx.update(handRef, { status: "ended" });
+          tx.update(tableRef, { currentHandId: null });
+        } else if (nextSeatInfo) {
+          const tc = toCallFor(contributions, nextSeatInfo.playerId);
+          tx.update(handRef, { actorSeatNum: ns, toCallCents: tc });
+        }
+      };
+
+      switch (intent.type) {
+        case "fold": {
+          folded[intent.playerId] = true;
+          tx.update(handRef, { folded });
+          const remaining = seats.filter(
+            (s) => !folded[s.playerId] && s.chipStackCents > 0
+          );
+          if (remaining.length <= 1) {
+            tx.update(handRef, { status: "ended" });
+            tx.update(tableRef, { currentHandId: null });
+            tx.delete(intentRef);
+            return;
+          }
+          next();
+          break;
+        }
+        case "check": {
+          if (toCall !== 0) {
+            tx.delete(intentRef);
+            return;
+          }
+          next();
+          break;
+        }
+        case "call": {
+          if (toCall === 0) {
+            next();
+            break;
+          }
+          const callAmt = Math.min(toCall, seat.chipStackCents);
+          contributions[intent.playerId] =
+            (contributions[intent.playerId] || 0) + callAmt;
+          pot += callAmt;
+          seat.chipStackCents -= callAmt;
+          updateSeat(intent.playerId, seat.chipStackCents);
+          tx.update(handRef, { contributions, potCents: pot });
+          actorSeatNum = seat.seatNum;
+          next();
+          break;
+        }
+        case "raise": {
+          if (
+            typeof intent.amountCents !== "number" ||
+            intent.amountCents < minRaiseCents
+          ) {
+            tx.delete(intentRef);
+            return;
+          }
+          const highest = highestContribution(contributions);
+          const playerContrib = contributions[intent.playerId] || 0;
+          const target = highest + intent.amountCents;
+          const needed = target - playerContrib;
+          const pay = Math.min(needed, seat.chipStackCents);
+          contributions[intent.playerId] = playerContrib + pay;
+          pot += pay;
+          seat.chipStackCents -= pay;
+          updateSeat(intent.playerId, seat.chipStackCents);
+          lastAggressorSeatNum = seat.seatNum;
+          minRaiseCents = intent.amountCents;
+          tx.update(handRef, {
+            contributions,
+            potCents: pot,
+            lastAggressorSeatNum,
+            minRaiseCents,
+          });
+
+          const remaining = seats.filter(
+            (s) => !folded[s.playerId] && s.chipStackCents > 0
+          );
+          if (remaining.length <= 1) {
+            tx.update(handRef, { status: "ended" });
+            tx.update(tableRef, { currentHandId: null });
+            tx.delete(intentRef);
+            return;
+          }
+          next();
+          break;
+        }
+        default:
+          tx.delete(intentRef);
+          return;
+      }
+
+      tx.delete(intentRef);
     });
   }
 );

--- a/public/table.html
+++ b/public/table.html
@@ -17,15 +17,16 @@
     <div id="error" class="card" style="display:none;"></div>
     <div id="table-info" class="card" style="margin-top:16px;"></div>
     <div id="current-hand" class="card" style="margin-top:16px;"></div>
+    <div id="action-panel" class="card" style="display:none;margin-top:16px;"></div>
     <div id="seats" class="card" style="margin-top:16px;"></div>
     <div id="debug-box" class="dbg" style="display:none;font-family:monospace;white-space:pre;font-size:11px;margin-top:12px;"></div>
   </div>
 
   <script type="module" src="/firebase-init.js"></script>
   <script type="module">
-    import { db, dollars, renderCurrentPlayerControls, isDebug, setDebug } from "/common.js";
+    import { db, dollars, renderCurrentPlayerControls, isDebug, setDebug, getCurrentPlayer } from "/common.js";
     import {
-      doc, onSnapshot, collection, query, orderBy
+      doc, onSnapshot, collection, query, orderBy, addDoc, serverTimestamp
     } from "https://www.gstatic.com/firebasejs/10.12.5/firebase-firestore.js";
 
     renderCurrentPlayerControls("you");
@@ -38,6 +39,7 @@
     const errorEl = document.getElementById('error');
     const infoEl = document.getElementById('table-info');
     const handEl = document.getElementById('current-hand');
+    const actionEl = document.getElementById('action-panel');
     const seatsEl = document.getElementById('seats');
     const debugBox = document.getElementById('debug-box');
 
@@ -100,6 +102,12 @@
       if (!handData) {
         const seatCount = seatData.filter(s => s.active).length;
         handEl.innerHTML = seatCount < 2 ? 'Waiting for players…' : 'Waiting for next dealer’s choice…';
+        actionEl.style.display = 'none';
+        return;
+      }
+      if (handData.status === 'ended') {
+        handEl.textContent = 'Hand ended — waiting for next hand…';
+        actionEl.style.display = 'none';
         return;
       }
       const h = handData;
@@ -108,6 +116,7 @@
       const dealerName = h.dealerName || getNameBySeat(h.positions?.dealerSeatNum);
       const sbName = getNameBySeat(h.positions?.sbSeatNum);
       const bbName = getNameBySeat(h.positions?.bbSeatNum);
+      const actorName = getNameBySeat(h.actorSeatNum);
       let contrib = '';
       if (h.contributions) {
         const parts = [];
@@ -122,7 +131,9 @@
         <div class="small" style="margin-top:4px;">Pot: ${dollars(h.potCents || 0)}</div>
         <div class="small">Positions: Dealer ${dealerName}, SB ${sbName}, BB ${bbName}</div>
         ${contrib}
+        <div class="small" style="margin-top:4px;">Action: ${actorName}</div>
       `;
+      renderActions();
     }
 
     function renderSeats() {
@@ -130,11 +141,61 @@
       seatsEl.innerHTML = `<h2 style="margin-top:0;">Seats</h2>${rows.join('') || '<div class="small">(none yet)</div>'}`;
     }
 
+    let intentPending = false;
+    async function renderActions() {
+      const current = getCurrentPlayer();
+      if (!handData || !current) { actionEl.style.display = 'none'; return; }
+      const folded = handData.folded || {};
+      const currentSeat = seatData.find(s => s.playerId === current.id);
+      const isActor = currentSeat && currentSeat.seatNum === handData.actorSeatNum && !folded[current.id] && (currentSeat.chipStackCents > 0);
+      if (!isActor) { actionEl.style.display = 'none'; return; }
+
+      const toCall = handData.toCallCents || 0;
+      const minRaise = handData.minRaiseCents || 0;
+      const callLabel = toCall > 0 ? `Call ${dollars(toCall)}` : 'Check';
+      const raiseLabel = `Min-Raise ${dollars(minRaise)}`;
+
+      actionEl.style.display = 'block';
+      actionEl.innerHTML = `
+        <div style="display:flex; gap:8px; flex-wrap:wrap;">
+          <button id="btn-fold">Fold</button>
+          <button id="btn-call">${callLabel}</button>
+          <button id="btn-raise">${raiseLabel}</button>
+        </div>
+      `;
+
+      const foldBtn = document.getElementById('btn-fold');
+      const callBtn = document.getElementById('btn-call');
+      const raiseBtn = document.getElementById('btn-raise');
+
+      const disable = (d) => { foldBtn.disabled = callBtn.disabled = raiseBtn.disabled = d; };
+
+      const intentsCol = collection(db, 'tables', tableId, 'hands', tableData.currentHandId, 'intents');
+
+      const send = async (data) => {
+        if (intentPending) return;
+        intentPending = true;
+        disable(true);
+        try {
+          await addDoc(intentsCol, { ...data, createdAt: serverTimestamp() });
+        } catch (e) {
+          console.error(e);
+        }
+        intentPending = false;
+        disable(false);
+      };
+
+      foldBtn.addEventListener('click', () => send({ playerId: current.id, type: 'fold' }));
+      callBtn.addEventListener('click', () => send({ playerId: current.id, type: toCall > 0 ? 'call' : 'check' }));
+      raiseBtn.addEventListener('click', () => send({ playerId: current.id, type: 'raise', amountCents: minRaise }));
+    }
+
     function updateDebug() {
       if (!isDebug()) { debugBox.style.display = 'none'; return; }
       debugBox.style.display = 'block';
       const pos = handData?.positions || {};
-      debugBox.textContent = `id=${tableId}\ncurrentHandId=${tableData?.currentHandId ?? 'null'}\nnextDealerId=${tableData?.nextDealerId ?? 'null'}\nnextDealerName=${tableData?.nextDealerName ?? 'null'}\nnextVariantId=${tableData?.nextVariantId ?? 'null'}\npositions=${pos.dealerSeatNum ?? 'null'},${pos.sbSeatNum ?? 'null'},${pos.bbSeatNum ?? 'null'}\nactiveSeatCount=${seatData.filter(s => s.active).length}`;
+      const folded = Object.keys(handData?.folded || {}).join(',');
+      debugBox.textContent = `id=${tableId}\ncurrentHandId=${tableData?.currentHandId ?? 'null'}\nnextDealerId=${tableData?.nextDealerId ?? 'null'}\nnextDealerName=${tableData?.nextDealerName ?? 'null'}\nnextVariantId=${tableData?.nextVariantId ?? 'null'}\npositions=${pos.dealerSeatNum ?? 'null'},${pos.sbSeatNum ?? 'null'},${pos.bbSeatNum ?? 'null'}\nactorSeatNum=${handData?.actorSeatNum ?? 'null'}\nlastAggressorSeatNum=${handData?.lastAggressorSeatNum ?? 'null'}\ntoCallCents=${handData?.toCallCents ?? 'null'}\nminRaiseCents=${handData?.minRaiseCents ?? 'null'}\nfolded=${folded}\nactiveSeatCount=${seatData.filter(s => s.active).length}`;
     }
   </script>
 </body>


### PR DESCRIPTION
## Summary
- implement server-validated preflop betting intents and turn order
- expose action buttons for current actor and show turn info
- allow clients to submit intents through Firestore rules

## Testing
- `npm --prefix functions run build`
- `firebase hosting:channel:deploy preview-$(date +%s)` *(fails: command not found)*

Firebase Hosting Preview: *(unable to generate in container; run deployment to obtain URL)*

------
https://chatgpt.com/codex/tasks/task_e_68c4aa3ccbbc832ebd1633b98ba4ca35