### PR TITLE
brief-11: deck + community cards + streets (preflop→flop→turn→river)

### DIFF
--- a/public/lobby.html
+++ b/public/lobby.html
@@ -48,11 +48,17 @@
       const rangeStr = `${dollars(d.minBuyInCents || 0)}–${dollars(d.maxBuyInCents || 0)} (default ${dollars(d.defaultBuyInCents || 0)})`;
       let banner;
       let potLine = "";
+      let stageLine = "";
+      let boardLine = "";
       let posLine = "";
       if (hand) {
         const vLabel = hand.variant === "omaha" ? "Omaha" : "Hold'em";
         banner = `Current Hand: ${vLabel} • Dealer: ${hand.dealerName || ""} • Status: ${hand.status}`;
         potLine = `<div class=\"small\">Pot: ${dollars(hand.potCents || 0)}</div>`;
+        const stageLabel = hand.stage ? hand.stage.charAt(0).toUpperCase() + hand.stage.slice(1) : "";
+        stageLine = `<div class=\"small\">Stage: ${stageLabel}</div>`;
+        const board = (hand.board || []).map(c => c.substring(0,5)).join(' ');
+        boardLine = `<div class=\"small\">Board: ${board}</div>`;
         const getName = (n) => seatMap?.find(s => s.seatNum === n)?.playerName || "(left)";
         const sbName = getName(hand.positions?.sbSeatNum);
         const bbName = getName(hand.positions?.bbSeatNum);
@@ -79,7 +85,7 @@
               <div class="small">Blinds: ${blindStr}</div>
               <div class="small">Buy-in: ${rangeStr}</div>
               <div class="small" style="margin-top:4px;">${banner}</div>
-              ${potLine}${posLine}
+              ${potLine}${stageLine}${boardLine}${posLine}
               <div class="small">${nextDealerLine}</div>
             </div>
             <div>
@@ -112,7 +118,8 @@
         if (b.hand) {
           const p = b.hand.positions || {};
           const contrib = b.hand.contributions ? JSON.stringify(b.hand.contributions) : '{}';
-          extra = `\npositions=${p.dealerSeatNum ?? 'null'},${p.sbSeatNum ?? 'null'},${p.bbSeatNum ?? 'null'}\ncontrib=${contrib}`;
+          const board = b.hand.board ? JSON.stringify(b.hand.board) : '[]';
+          extra = `\npositions=${p.dealerSeatNum ?? 'null'},${p.sbSeatNum ?? 'null'},${p.bbSeatNum ?? 'null'}\nstage=${b.hand.stage ?? 'null'}\nboard=${board}\ncontrib=${contrib}`;
         }
         el.textContent = `id=${b.id}\nseats=${b.seatCount}\ncurrentHandId=${b.data.currentHandId ?? 'null'}\nnextDealer=${ndName} (${ndId})\nnextVariantId=${b.data.nextVariantId ?? 'null'}${extra}`;
       } else {

--- a/public/table.html
+++ b/public/table.html
@@ -106,17 +106,19 @@
         return;
       }
       if (handData.status === 'ended') {
-        handEl.textContent = 'Hand ended — waiting for next hand…';
+        handEl.textContent = handData.showdownPending ? 'Showdown pending — pot held' : 'Hand ended — waiting for next hand…';
         actionEl.style.display = 'none';
         return;
       }
       const h = handData;
       const vLabel = h.variant === 'omaha' ? 'Omaha' : "Hold'em";
+      const stageLabel = h.stage ? h.stage.charAt(0).toUpperCase() + h.stage.slice(1) : '';
       const getNameBySeat = (n) => seatData.find(s => s.seatNum === n)?.playerName || '(left)';
       const dealerName = h.dealerName || getNameBySeat(h.positions?.dealerSeatNum);
       const sbName = getNameBySeat(h.positions?.sbSeatNum);
       const bbName = getNameBySeat(h.positions?.bbSeatNum);
       const actorName = getNameBySeat(h.actorSeatNum);
+      const board = (h.board || []).map(c => `[ ${c} ]`).join(' ');
       let contrib = '';
       if (h.contributions) {
         const parts = [];
@@ -129,6 +131,8 @@
       handEl.innerHTML = `
         <div>Current Hand: ${vLabel} • Dealer: ${dealerName} • Status: ${h.status}</div>
         <div class="small" style="margin-top:4px;">Pot: ${dollars(h.potCents || 0)}</div>
+        <div class="small">Board: ${board || '(none)'}</div>
+        <div class="small">Stage: ${stageLabel}</div>
         <div class="small">Positions: Dealer ${dealerName}, SB ${sbName}, BB ${bbName}</div>
         ${contrib}
         <div class="small" style="margin-top:4px;">Action: ${actorName}</div>
@@ -195,7 +199,7 @@
       debugBox.style.display = 'block';
       const pos = handData?.positions || {};
       const folded = Object.keys(handData?.folded || {}).join(',');
-      debugBox.textContent = `id=${tableId}\ncurrentHandId=${tableData?.currentHandId ?? 'null'}\nnextDealerId=${tableData?.nextDealerId ?? 'null'}\nnextDealerName=${tableData?.nextDealerName ?? 'null'}\nnextVariantId=${tableData?.nextVariantId ?? 'null'}\npositions=${pos.dealerSeatNum ?? 'null'},${pos.sbSeatNum ?? 'null'},${pos.bbSeatNum ?? 'null'}\nactorSeatNum=${handData?.actorSeatNum ?? 'null'}\nlastAggressorSeatNum=${handData?.lastAggressorSeatNum ?? 'null'}\ntoCallCents=${handData?.toCallCents ?? 'null'}\nminRaiseCents=${handData?.minRaiseCents ?? 'null'}\nfolded=${folded}\nactiveSeatCount=${seatData.filter(s => s.active).length}`;
+      debugBox.textContent = `id=${tableId}\ncurrentHandId=${tableData?.currentHandId ?? 'null'}\nnextDealerId=${tableData?.nextDealerId ?? 'null'}\nnextDealerName=${tableData?.nextDealerName ?? 'null'}\nnextVariantId=${tableData?.nextVariantId ?? 'null'}\npositions=${pos.dealerSeatNum ?? 'null'},${pos.sbSeatNum ?? 'null'},${pos.bbSeatNum ?? 'null'}\nstage=${handData?.stage ?? 'null'}\nactorSeatNum=${handData?.actorSeatNum ?? 'null'}\nlastAggressorSeatNum=${handData?.lastAggressorSeatNum ?? 'null'}\nroundStartSeatNum=${handData?.roundStartSeatNum ?? 'null'}\ntoCallCents=${handData?.toCallCents ?? 'null'}\nminRaiseCents=${handData?.minRaiseCents ?? 'null'}\ndeckIndex=${handData?.deckIndex ?? 'null'}\nboard=${JSON.stringify(handData?.board || [])}\nfolded=${folded}\nactiveSeatCount=${seatData.filter(s => s.active).length}`;
     }
   </script>
 </body>


### PR DESCRIPTION
## Summary
- generate and shuffle deck server-side; deal board and track betting stage
- advance hand through flop/turn/river, auto-awarding pot on folds and flagging showdown
- show board cards and stage in table and lobby UIs with debug info

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

[Firebase preview](https://jampoker--brief-11-streets-and-board.web.app)

------
https://chatgpt.com/codex/tasks/task_e_68c4aeeb488c832eaf92d125fa0ae3d4