### PR TITLE
brief-11a: Board UI + stage labels

### DIFF
--- a/public/common.js
+++ b/public/common.js
@@ -18,6 +18,16 @@ export const parseDollarsToCents = (input) => {
   return Math.max(0, Math.round(value * 100));
 };
 
+export const formatCard = (code) => `[ ${code} ]`;
+
+export const stageLabel = (hand) => {
+  const s = hand?.stage;
+  if (s === 'flop') return 'Flop';
+  if (s === 'turn') return 'Turn';
+  if (s === 'river') return 'River';
+  return 'Preflop';
+};
+
 const LS_KEY_ID = "currentPlayerId";
 const LS_KEY_NAME = "currentPlayerName";
 

--- a/public/lobby.html
+++ b/public/lobby.html
@@ -26,7 +26,7 @@
 
   <script type="module" src="/firebase-init.js"></script>
   <script type="module">
-    import { db, dollars, parseDollarsToCents, getCurrentPlayer, renderCurrentPlayerControls, isDebug, setDebug } from "/common.js";
+    import { db, dollars, parseDollarsToCents, getCurrentPlayer, renderCurrentPlayerControls, isDebug, setDebug, formatCard, stageLabel } from "/common.js";
     import {
       collection, query, orderBy, onSnapshot, doc, collection as subcol,
       runTransaction, serverTimestamp, getDoc, updateDoc
@@ -55,10 +55,11 @@
         const vLabel = hand.variant === "omaha" ? "Omaha" : "Hold'em";
         banner = `Current Hand: ${vLabel} • Dealer: ${hand.dealerName || ""} • Status: ${hand.status}`;
         potLine = `<div class=\"small\">Pot: ${dollars(hand.potCents || 0)}</div>`;
-        const stageLabel = hand.stage ? hand.stage.charAt(0).toUpperCase() + hand.stage.slice(1) : "";
-        stageLine = `<div class=\"small\">Stage: ${stageLabel}</div>`;
-        const board = (hand.board || []).map(c => c.substring(0,5)).join(' ');
-        boardLine = `<div class=\"small\">Board: ${board}</div>`;
+        stageLine = `<div class=\"small\">Stage: ${stageLabel(hand)}</div>`;
+        if (hand.board && hand.board.length) {
+          const board = hand.board.map(c => `<span class=\"card-chip\" style=\"font-size:12px;\">${formatCard(c)}</span>`).join(' ');
+          boardLine = `<div class=\"small\">Board: ${board}</div>`;
+        }
         const getName = (n) => seatMap?.find(s => s.seatNum === n)?.playerName || "(left)";
         const sbName = getName(hand.positions?.sbSeatNum);
         const bbName = getName(hand.positions?.bbSeatNum);

--- a/public/style.css
+++ b/public/style.css
@@ -8,3 +8,4 @@ html,body{ margin:0; padding:0; font-family:system-ui,-apple-system,Arial,sans-s
 .card{ background:var(--card); border:1px solid #334155; border-radius:14px; padding:18px; }
 h1{ margin:0 0 8px 0; font-size:28px; }
 .small{ opacity:.7; font-size:14px; }
+.card-chip{ display:inline-block; padding:2px 4px; border:1px solid #334155; border-radius:4px; margin-right:4px; }

--- a/public/table.html
+++ b/public/table.html
@@ -24,7 +24,7 @@
 
   <script type="module" src="/firebase-init.js"></script>
   <script type="module">
-    import { db, dollars, renderCurrentPlayerControls, isDebug, setDebug, getCurrentPlayer } from "/common.js";
+    import { db, dollars, renderCurrentPlayerControls, isDebug, setDebug, getCurrentPlayer, formatCard, stageLabel } from "/common.js";
     import {
       doc, onSnapshot, collection, query, orderBy, addDoc, serverTimestamp
     } from "https://www.gstatic.com/firebasejs/10.12.5/firebase-firestore.js";
@@ -112,13 +112,13 @@
       }
       const h = handData;
       const vLabel = h.variant === 'omaha' ? 'Omaha' : "Hold'em";
-      const stageLabel = h.stage ? h.stage.charAt(0).toUpperCase() + h.stage.slice(1) : '';
+      const stageStr = stageLabel(h);
       const getNameBySeat = (n) => seatData.find(s => s.seatNum === n)?.playerName || '(left)';
       const dealerName = h.dealerName || getNameBySeat(h.positions?.dealerSeatNum);
       const sbName = getNameBySeat(h.positions?.sbSeatNum);
       const bbName = getNameBySeat(h.positions?.bbSeatNum);
       const actorName = getNameBySeat(h.actorSeatNum);
-      const board = (h.board || []).map(c => `[ ${c} ]`).join(' ');
+      const board = (h.board || []).map(c => `<span class="card-chip">${formatCard(c)}</span>`).join(' ');
       let contrib = '';
       if (h.contributions) {
         const parts = [];
@@ -128,14 +128,21 @@
         }
         if (parts.length) contrib = `<div class="small">${parts.join(', ')}</div>`;
       }
+      const boardLine = (h.board && h.board.length)
+        ? `<div class="small">Board: ${board}</div>`
+        : '';
+      const debugLine = isDebug()
+        ? `<div class="small">board=${(h.board||[]).join(',')}${h.deckIndex !== undefined ? ` deckIndex=${h.deckIndex}` : ''}</div>`
+        : '';
       handEl.innerHTML = `
         <div>Current Hand: ${vLabel} • Dealer: ${dealerName} • Status: ${h.status}</div>
         <div class="small" style="margin-top:4px;">Pot: ${dollars(h.potCents || 0)}</div>
-        <div class="small">Board: ${board || '(none)'}</div>
-        <div class="small">Stage: ${stageLabel}</div>
+        <div class="small">Stage: ${stageStr}</div>
+        ${boardLine}
         <div class="small">Positions: Dealer ${dealerName}, SB ${sbName}, BB ${bbName}</div>
         ${contrib}
         <div class="small" style="margin-top:4px;">Action: ${actorName}</div>
+        ${debugLine}
       `;
       renderActions();
     }


### PR DESCRIPTION
## Summary
- show stage and board chips on table and lobby views
- share helpers for formatting cards and stage labels
- add basic chip styling

## Testing
- `npm test` *(fails: enoent package.json)*
- `node --check public/common.js`

Firebase Hosting Preview: https://brief-11a-board-ui--jam-poker.web.app

------
https://chatgpt.com/codex/tasks/task_e_68c4b4036420832e8f56120e487bbfe8