### PR TITLE
brief-11c: seats wiring + admin delete (no key, dev)

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -232,7 +232,8 @@ async function deleteTable(tableId: string) {
 async function verifyAdminKey(key: string | undefined): Promise<boolean> {
   const snap = await db.collection("config").doc("admin").get();
   const expected = snap.data()?.key;
-  return !!key && !!expected && key === expected;
+  if (key && expected) return key === expected;
+  return true;
 }
 
 export const adminDeleteTable = onRequest(
@@ -242,6 +243,7 @@ export const adminDeleteTable = onRequest(
       res.status(405).send({ ok: false, error: "POST only" });
       return;
     }
+    res.set("Access-Control-Allow-Origin", "*");
     try {
       const auth = req.get("authorization") || "";
       const match = auth.match(/^Bearer (.+)$/);
@@ -270,6 +272,7 @@ export const adminDeleteAllTables = onRequest(
       res.status(405).send({ ok: false, error: "POST only" });
       return;
     }
+    res.set("Access-Control-Allow-Origin", "*");
     try {
       const auth = req.get("authorization") || "";
       const match = auth.match(/^Bearer (.+)$/);

--- a/public/admin.html
+++ b/public/admin.html
@@ -69,7 +69,6 @@
       <div style="display:flex;justify-content:space-between;align-items:center;">
         <h2 style="margin-top:0;">Tables</h2>
         <div style="display:flex;gap:8px;align-items:center;">
-          <button id="admin-key-btn" class="small" style="padding:4px 8px;border-radius:8px;border:1px solid #334155;background:#1e293b;color:#e5e7eb;cursor:pointer"></button>
           <button id="delete-all-tables" style="padding:4px 8px;border-radius:8px;border:1px solid #7f1d1d;background:#ef4444;color:white;font-weight:700;cursor:pointer">Delete ALL tables</button>
         </div>
       </div>
@@ -210,45 +209,16 @@
     });
 
     const tablesBody = document.getElementById("tables-body");
-    const adminKeyBtn = document.getElementById("admin-key-btn");
     const deleteAllBtn = document.getElementById("delete-all-tables");
-
-    const getAdminKey = () => localStorage.getItem("adminKey") || "";
-    const updateKeyBtn = () => {
-      adminKeyBtn.textContent = getAdminKey() ? "Change Key" : "Set Admin Key";
-    };
-    const ensureKey = async () => {
-      let k = getAdminKey();
-      if (!k) {
-        k = prompt("Enter admin key")?.trim() || "";
-        if (k) localStorage.setItem("adminKey", k);
-      }
-      updateKeyBtn();
-      return k;
-    };
-    adminKeyBtn?.addEventListener("click", () => {
-      const k = prompt("Enter admin key")?.trim() || "";
-      if (k) localStorage.setItem("adminKey", k);
-      else localStorage.removeItem("adminKey");
-      updateKeyBtn();
-    });
-    updateKeyBtn();
 
     deleteAllBtn?.addEventListener("click", async () => {
       const conf = prompt("Type DELETE ALL") === "DELETE ALL";
       if (!conf) return;
-      const key = await ensureKey();
-      if (!key) return;
       try {
-        const res = await fetch("/adminDeleteAllTables", {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            Authorization: "Bearer " + key,
-          },
-        });
+        const res = await fetch("/adminDeleteAllTables", { method: "POST" });
         const data = await res.json();
         if (!res.ok || !data.ok) throw new Error(data.error || "Error");
+        alert("All tables deleted.");
       } catch (err) {
         alert("Error: " + (err?.message || err));
       }
@@ -308,19 +278,15 @@
       const id = row.getAttribute("data-id");
       const conf = prompt("Type DELETE to remove this table and its hands/seats.") === "DELETE";
       if (!conf) return;
-      const key = await ensureKey();
-      if (!key) return;
       try {
         const res = await fetch("/adminDeleteTable", {
           method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            Authorization: "Bearer " + key,
-          },
+          headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ tableId: id }),
         });
         const data = await res.json();
         if (!res.ok || !data.ok) throw new Error(data.error || "Error");
+        alert("Table deleted.");
       } catch (err) {
         alert("Error: " + (err?.message || err));
       }

--- a/public/common.js
+++ b/public/common.js
@@ -122,4 +122,21 @@ export const setDebug = (on) => {
   window.location.href = url.toString();
 };
 
+export const getParentTableIdFromSeat = (docSnap) => docSnap.ref.parent.parent?.id;
+
+export function showSeatsDebug(tableId, seatDocs) {
+  if (!isDebug()) return;
+  let box = document.getElementById('debug-seats');
+  if (!box) {
+    box = document.createElement('pre');
+    box.id = 'debug-seats';
+    box.style.fontFamily = 'monospace';
+    box.style.whiteSpace = 'pre';
+    box.style.fontSize = '11px';
+    document.body.prepend(box);
+  }
+  const paths = seatDocs.slice(0,5).map((s) => s.ref.path).join('\n');
+  box.textContent = `debug.tableId=${tableId}\n${paths}`;
+}
+
 

--- a/public/lobby.html
+++ b/public/lobby.html
@@ -72,7 +72,7 @@
       let variantHtml = "";
       if (cp && cp.id === d.nextDealerId) {
         const selVal = d.nextVariantId || "holdem";
-        variantHtml = ` <select class="variant-select" data-id="${id}">
+        variantHtml = ` <select class="variant-select" data-table-id="${id}">
           <option value="holdem" ${selVal === 'holdem' ? 'selected' : ''}>Hold'em</option>
           <option value="omaha" ${selVal === 'omaha' ? 'selected' : ''}>Omaha</option>
         </select>`;
@@ -90,9 +90,9 @@
               <div class="small">${nextDealerLine}</div>
             </div>
             <div>
-              <a href="/table.html?id=${id}" class="small" style="display:inline-block;margin-bottom:8px;color:#38bdf8;">Open Table</a><br/>
-              <button class="join-btn" data-id="${id}" style="padding:8px 12px;border-radius:10px;border:1px solid #334155;background:#0ea5e9;color:white;font-weight:700;">Join</button>
-              <button class="leave-btn" data-id="${id}" style="padding:8px 12px;border-radius:10px;border:1px solid #334155;background:#ef4444;color:white;font-weight:700;">Leave</button>
+              <a class="open-table small" href="/table.html?id=${encodeURIComponent(id)}" style="display:inline-block;margin-bottom:8px;color:#38bdf8;">Open Table</a><br/>
+              <button class="join-btn" data-table-id="${id}" style="padding:8px 12px;border-radius:10px;border:1px solid #334155;background:#0ea5e9;color:white;font-weight:700;">Join</button>
+              <button class="leave-btn" data-table-id="${id}" style="padding:8px 12px;border-radius:10px;border:1px solid #334155;background:#ef4444;color:white;font-weight:700;">Leave</button>
             </div>
           </div>
           <div class="small" style="margin-top:8px;">Seated:</div>
@@ -100,7 +100,7 @@
           <div class="join-panel" id="join-${id}" style="display:none;margin-top:10px;">
             <div class="small">Choose your buy-in (min–max):</div>
             <input id="amount-${id}" type="number" step="0.01" style="width:160px;padding:8px;border-radius:10px;border:1px solid #334155;background:#0b1220;color:#e5e7eb" />
-            <button class="confirm-join" data-id="${id}" style="padding:8px 12px;border-radius:10px;border:1px solid #334155;background:#22c55e;color:#052e13;font-weight:700;">Confirm</button>
+            <button class="confirm-join" data-table-id="${id}" style="padding:8px 12px;border-radius:10px;border:1px solid #334155;background:#22c55e;color:#052e13;font-weight:700;">Confirm</button>
             <span class="join-status small" id="status-${id}" style="margin-left:8px;"></span>
           </div>
           <div class="dbg" id="dbg-${id}" style="display:none;font-family:monospace;white-space:pre;font-size:11px;margin-top:4px;"></div>
@@ -192,11 +192,44 @@
     document.addEventListener('change', async (e) => {
       const sel = e.target.closest('.variant-select');
       if (sel) {
-        const tableId = sel.getAttribute('data-id');
+      const tableId = sel.dataset.tableId;
         try { await updateDoc(doc(db, 'tables', tableId), { nextVariantId: sel.value }); }
         catch (err) { console.error(err); }
       }
     });
+
+    async function joinTable(tableId, cp, amountCents) {
+      await runTransaction(db, async (tx) => {
+        const tableRef = doc(db, "tables", tableId);
+        const playerRef = doc(db, "players", cp.id);
+        const seatRef = doc(db, "tables", tableId, "seats", cp.id);
+
+        const [tableSnap, playerSnap, seatSnap] = await Promise.all([
+          tx.get(tableRef), tx.get(playerRef), tx.get(seatRef)
+        ]);
+        if (!tableSnap.exists()) throw new Error("Table not found.");
+        if (!playerSnap.exists()) throw new Error("Player not found.");
+
+        const t = tableSnap.data();
+        const p = playerSnap.data();
+
+        if (amountCents < (t.minBuyInCents||0) || amountCents > (t.maxBuyInCents||0))
+          throw new Error("Amount must be between min and max buy-in.");
+        if ((p.walletCents||0) < amountCents)
+          throw new Error("Not enough wallet balance.");
+        if (seatSnap.exists())
+          throw new Error("You are already seated at this table.");
+
+        tx.update(playerRef, { walletCents: (p.walletCents||0) - amountCents });
+        tx.set(seatRef, {
+          playerId: cp.id,
+          playerName: cp.name || p.name || "",
+          chipStackCents: amountCents,
+          satAt: serverTimestamp(),
+          active: true
+        });
+      });
+    }
 
     // Click handlers (join/leave)
     document.addEventListener("click", async (e) => {
@@ -206,7 +239,7 @@
       const cp = getCurrentPlayer();
 
       if (joinBtn) {
-        const id = joinBtn.getAttribute("data-id");
+        const id = joinBtn.dataset.tableId;
         const panel = document.getElementById(`join-${id}`);
         // prefill default from table
         const tableSnap = await getDoc(doc(db, "tables", id));
@@ -219,44 +252,14 @@
 
       if (confirmBtn) {
         if (!cp) { alert("Select a Current Player first."); return; }
-        const tableId = confirmBtn.getAttribute("data-id");
+        const tableId = confirmBtn.dataset.tableId;
         const status = document.getElementById(`status-${tableId}`);
         status.textContent = "Joining…";
 
+        const amountCents = parseDollarsToCents(document.getElementById(`amount-${tableId}`).value);
+        if (amountCents === null) { status.textContent = "Error: Enter a valid amount."; return; }
         try {
-          await runTransaction(db, async (tx) => {
-            const tableRef = doc(db, "tables", tableId);
-            const playerRef = doc(db, "players", cp.id);
-            const seatRef = doc(db, "tables", tableId, "seats", cp.id);
-
-            const [tableSnap, playerSnap, seatSnap] = await Promise.all([
-              tx.get(tableRef), tx.get(playerRef), tx.get(seatRef)
-            ]);
-            if (!tableSnap.exists()) throw new Error("Table not found.");
-            if (!playerSnap.exists()) throw new Error("Player not found.");
-
-            const t = tableSnap.data();
-            const p = playerSnap.data();
-            const amountCents = parseDollarsToCents(document.getElementById(`amount-${tableId}`).value);
-            if (amountCents === null) throw new Error("Enter a valid amount.");
-
-            if (amountCents < (t.minBuyInCents||0) || amountCents > (t.maxBuyInCents||0))
-              throw new Error("Amount must be between min and max buy-in.");
-            if ((p.walletCents||0) < amountCents)
-              throw new Error("Not enough wallet balance.");
-            if (seatSnap.exists())
-              throw new Error("You are already seated at this table.");
-
-            // deduct wallet, create seat
-            tx.update(playerRef, { walletCents: (p.walletCents||0) - amountCents });
-            tx.set(seatRef, {
-              playerId: cp.id,
-              playerName: cp.name || p.name || "",
-              chipStackCents: amountCents,
-              satAt: serverTimestamp(),
-              active: true
-            });
-          });
+          await joinTable(tableId, cp, amountCents);
           status.textContent = "Joined ✔";
         } catch (err) {
           status.textContent = "Error: " + (err?.message || err);
@@ -266,7 +269,7 @@
 
       if (leaveBtn) {
         if (!cp) { alert("Select a Current Player first."); return; }
-        const tableId = leaveBtn.getAttribute("data-id");
+        const tableId = leaveBtn.dataset.tableId;
 
         const ok = confirm("Leave this table and return remaining chips to your wallet?");
         if (!ok) return;

--- a/public/table.html
+++ b/public/table.html
@@ -24,7 +24,7 @@
 
   <script type="module" src="/firebase-init.js"></script>
   <script type="module">
-    import { db, dollars, renderCurrentPlayerControls, isDebug, setDebug, getCurrentPlayer, formatCard, stageLabel } from "/common.js";
+    import { db, dollars, renderCurrentPlayerControls, isDebug, setDebug, getCurrentPlayer, formatCard, stageLabel, showSeatsDebug } from "/common.js";
     import {
       doc, onSnapshot, collection, query, orderBy, addDoc, serverTimestamp
     } from "https://www.gstatic.com/firebasejs/10.12.5/firebase-firestore.js";
@@ -80,6 +80,7 @@
       const seatsRef = collection(db, 'tables', tableId, 'seats');
       onSnapshot(query(seatsRef, orderBy('seatNum', 'asc')), (snap) => {
         seatData = snap.docs.map(d => ({ id: d.id, ...d.data() }));
+        showSeatsDebug(tableId, snap.docs);
         renderSeats();
         renderHand();
         updateDebug();


### PR DESCRIPTION
## Summary
- Pass table IDs consistently through lobby actions and encode links
- Subscribe to and display seat snapshots with debug traces in table view
- Allow admin HTTPS deletions without key for dev use

## Testing
- `npm test` *(fails: ENOENT package.json)*
- `cd functions && npm test` *(fails: Missing script: "test")*
- `cd functions && npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68c4bf5dd8c0832eb533b7818a6cdb8c