### PR TITLE
feat: add seat occupancy tracking and table archiving

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -94,7 +94,7 @@
     import { db, dollars, parseDollarsToCents, renderCurrentPlayerControls } from "/common.js";
     import {
       collection, addDoc, serverTimestamp, query, orderBy, onSnapshot,
-      doc, updateDoc, deleteDoc
+      doc, updateDoc, deleteDoc, setDoc
     } from "https://www.gstatic.com/firebasejs/10.12.5/firebase-firestore.js";
 
     renderCurrentPlayerControls("you");
@@ -199,13 +199,36 @@
 
       tStatus.textContent = "Creating…"; tBtn.disabled = true;
       try {
-        await addDoc(tablesCol, {
-          name, minBuyInCents: minC, maxBuyInCents: maxC, defaultBuyInCents: defC,
-          smallBlindCents: sbC, bigBlindCents: bbC, active: true, createdAt: serverTimestamp()
+        const tableRef = await addDoc(tablesCol, {
+          name,
+          minBuyInCents: minC,
+          maxBuyInCents: maxC,
+          defaultBuyInCents: defC,
+          smallBlindCents: sbC,
+          bigBlindCents: bbC,
+          maxSeats: 6,
+          activeSeatCount: 0,
+          active: true,
+          deletedAt: null,
+          createdAt: serverTimestamp(),
         });
+        const seatsCol = collection(tableRef, "seats");
+        for (let i = 0; i < 6; i++) {
+          await setDoc(doc(seatsCol, String(i)), {
+            seatIndex: i,
+            occupiedBy: null,
+            displayName: null,
+            sittingOut: false,
+            stackCents: null,
+            updatedAt: serverTimestamp(),
+          });
+        }
         tStatus.textContent = "Table created ✔"; tName.value = "";
-      } catch (e) { tStatus.textContent = "Error: " + (e?.message || e); }
-      finally { tBtn.disabled = false; }
+      } catch (e) {
+        tStatus.textContent = "Error: " + (e?.message || e);
+      } finally {
+        tBtn.disabled = false;
+      }
     });
 
     const tablesBody = document.getElementById("tables-body");
@@ -239,7 +262,7 @@
           <td style="padding:8px;border-bottom:1px solid #334155;">${seated}</td>
           <td style="padding:8px;border-bottom:1px solid #334155;text-align:right;">
             <a href="/table.html?id=${id}" style="padding:4px 8px;border-radius:8px;border:1px solid #334155;background:#0ea5e9;color:white;font-size:12px;text-decoration:none;">Open</a>
-            <button class="del-table" style="padding:4px 8px;border-radius:8px;border:1px solid #7f1d1d;background:#ef4444;color:white;font-size:12px;cursor:pointer;">Delete</button>
+            <button class="archive-table" style="padding:4px 8px;border-radius:8px;border:1px solid #7f1d1d;background:#ef4444;color:white;font-size:12px;cursor:pointer;">Archive</button>
           </td>
         </tr>`;
       });
@@ -263,7 +286,12 @@
           if (!seatUnsubs[id]) {
             const seatsCol = collection(doc(db, "tables", id), "seats");
             seatUnsubs[id] = onSnapshot(seatsCol, (s) => {
-              seatCounts[id] = s.size;
+              let cnt = 0;
+              s.forEach((docSnap) => {
+                const sd = docSnap.data();
+                if (sd.occupiedBy) cnt++;
+              });
+              seatCounts[id] = cnt;
               renderTables();
             });
           }
@@ -273,20 +301,17 @@
     });
 
     tablesBody?.addEventListener("click", async (e) => {
-      if (!e.target.classList.contains("del-table")) return;
+      if (!e.target.classList.contains("archive-table")) return;
       const row = e.target.closest("tr");
       const id = row.getAttribute("data-id");
-      const conf = prompt("Type DELETE to remove this table and its hands/seats.") === "DELETE";
+      const conf = confirm("Archive this table?");
       if (!conf) return;
       try {
-        const res = await fetch("/adminDeleteTable", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ tableId: id }),
+        await updateDoc(doc(db, "tables", id), {
+          active: false,
+          deletedAt: serverTimestamp(),
         });
-        const data = await res.json();
-        if (!res.ok || !data.ok) throw new Error(data.error || "Error");
-        alert("Table deleted.");
+        alert("Table archived.");
       } catch (err) {
         alert("Error: " + (err?.message || err));
       }

--- a/public/lobby.html
+++ b/public/lobby.html
@@ -28,8 +28,8 @@
   <script type="module">
     import { db, dollars, parseDollarsToCents, getCurrentPlayer, renderCurrentPlayerControls, isDebug, setDebug, formatCard, stageLabel } from "/common.js";
     import {
-      collection, query, orderBy, onSnapshot, doc, collection as subcol,
-      runTransaction, serverTimestamp, getDoc, updateDoc
+      collection, query, orderBy, where, onSnapshot, doc, collection as subcol,
+      runTransaction, serverTimestamp, increment, getDoc, updateDoc
     } from "https://www.gstatic.com/firebasejs/10.12.5/firebase-firestore.js";
 
     renderCurrentPlayerControls("you");
@@ -133,7 +133,7 @@
       blocks.forEach(updateDebug);
     };
 
-    onSnapshot(query(tablesCol, orderBy("createdAt", "desc")), (snap) => {
+    onSnapshot(query(tablesCol, where("active", "!=", false), orderBy("active"), orderBy("createdAt", "desc")), (snap) => {
       blocks = [];
       seatUnsubs.forEach(u => u());
       seatUnsubs.clear();
@@ -150,15 +150,15 @@
           const seated = [];
           const seatMap = [];
           let activeCount = 0;
-          seatSnap.forEach(s => {
+          seatSnap.forEach((s) => {
             const sd = s.data();
-            if (sd.active !== false) {
-              seated.push(`<div style=\\"display:flex;justify-content:space-between;\\"><span>${sd.playerName || sd.playerId}</span><span>${dollars(sd.chipStackCents || 0)}</span></div>`);
-              seatMap.push({ seatNum: sd.seatNum, playerName: sd.playerName || sd.playerId });
+            if (sd.occupiedBy) {
+              seated.push(`<div style=\\"display:flex;justify-content:space-between;\\"><span>${sd.displayName || sd.occupiedBy}</span><span>${dollars(sd.stackCents || 0)}</span></div>`);
+              seatMap.push({ seatNum: sd.seatIndex, playerName: sd.displayName || sd.occupiedBy });
               activeCount++;
             }
           });
-          const idx = blocks.findIndex(b => b.id === id);
+          const idx = blocks.findIndex((b) => b.id === id);
           if (idx >= 0) {
             blocks[idx].seatsHtml = seated.join("") || "(none yet)";
             blocks[idx].seatCount = activeCount;
@@ -202,10 +202,10 @@
       await runTransaction(db, async (tx) => {
         const tableRef = doc(db, "tables", tableId);
         const playerRef = doc(db, "players", cp.id);
-        const seatRef = doc(db, "tables", tableId, "seats", cp.id);
 
-        const [tableSnap, playerSnap, seatSnap] = await Promise.all([
-          tx.get(tableRef), tx.get(playerRef), tx.get(seatRef)
+        const [tableSnap, playerSnap] = await Promise.all([
+          tx.get(tableRef),
+          tx.get(playerRef),
         ]);
         if (!tableSnap.exists()) throw new Error("Table not found.");
         if (!playerSnap.exists()) throw new Error("Player not found.");
@@ -213,21 +213,45 @@
         const t = tableSnap.data();
         const p = playerSnap.data();
 
-        if (amountCents < (t.minBuyInCents||0) || amountCents > (t.maxBuyInCents||0))
+        if (amountCents < (t.minBuyInCents || 0) || amountCents > (t.maxBuyInCents || 0))
           throw new Error("Amount must be between min and max buy-in.");
-        if ((p.walletCents||0) < amountCents)
+        if ((p.walletCents || 0) < amountCents)
           throw new Error("Not enough wallet balance.");
-        if (seatSnap.exists())
-          throw new Error("You are already seated at this table.");
+        const maxSeats = t.maxSeats || 0;
+        if ((t.activeSeatCount || 0) >= maxSeats)
+          throw new Error("Table full.");
+        let seatRef = null;
+        let seatIndex = -1;
+        for (let i = 0; i < maxSeats; i++) {
+          const sr = doc(db, "tables", tableId, "seats", String(i));
+          const ss = await tx.get(sr);
+          const sd = ss.data();
+          if (sd?.occupiedBy === cp.id)
+            throw new Error("You are already seated at this table.");
+          if (!ss.exists || !sd?.occupiedBy) {
+            if (seatRef === null) {
+              seatRef = sr;
+              seatIndex = i;
+            }
+          }
+        }
+        if (!seatRef) throw new Error("No available seats.");
 
-        tx.update(playerRef, { walletCents: (p.walletCents||0) - amountCents });
+        tx.update(playerRef, { walletCents: (p.walletCents || 0) - amountCents });
         tx.set(seatRef, {
+          seatIndex,
+          seatNum: seatIndex,
+          occupiedBy: cp.id,
           playerId: cp.id,
+          displayName: cp.name || p.name || "",
           playerName: cp.name || p.name || "",
+          sittingOut: false,
+          stackCents: amountCents,
           chipStackCents: amountCents,
-          satAt: serverTimestamp(),
-          active: true
+          updatedAt: serverTimestamp(),
+          active: true,
         });
+        tx.update(tableRef, { activeSeatCount: increment(1) });
       });
     }
 
@@ -277,17 +301,40 @@
         try {
           await runTransaction(db, async (tx) => {
             const playerRef = doc(db, "players", cp.id);
-            const seatRef = doc(db, "tables", tableId, "seats", cp.id);
-
-            const [playerSnap, seatSnap] = await Promise.all([tx.get(playerRef), tx.get(seatRef)]);
-            if (!seatSnap.exists()) throw new Error("You are not seated here.");
+            const tableRef = doc(db, "tables", tableId);
+            const playerSnap = await tx.get(playerRef);
+            const tableSnap = await tx.get(tableRef);
+            const maxSeats = tableSnap.data()?.maxSeats || 0;
+            let seatRef = null;
+            let seatSnap = null;
+            for (let i = 0; i < maxSeats; i++) {
+              const sr = doc(db, "tables", tableId, "seats", String(i));
+              const ss = await tx.get(sr);
+              if (ss.exists && ss.data()?.occupiedBy === cp.id) {
+                seatRef = sr;
+                seatSnap = ss;
+                break;
+              }
+            }
+            if (!seatRef || !seatSnap) throw new Error("You are not seated here.");
 
             const p = playerSnap.data() || {};
             const s = seatSnap.data();
-            const newWallet = (p.walletCents || 0) + (s.chipStackCents || 0);
+            const newWallet = (p.walletCents || 0) + (s.stackCents || 0);
 
             tx.update(playerRef, { walletCents: newWallet });
-            tx.delete(seatRef);
+            tx.update(seatRef, {
+              occupiedBy: null,
+              playerId: null,
+              displayName: null,
+              playerName: null,
+              sittingOut: false,
+              stackCents: null,
+              chipStackCents: null,
+              updatedAt: serverTimestamp(),
+              active: false,
+            });
+            tx.update(tableRef, { activeSeatCount: increment(-1) });
           });
           alert("You left the table. Chips returned to wallet.");
         } catch (err) {

--- a/public/table.html
+++ b/public/table.html
@@ -78,11 +78,12 @@
       });
 
       const seatsRef = collection(db, 'tables', tableId, 'seats');
-      onSnapshot(query(seatsRef, orderBy('seatNum', 'asc')), (snap) => {
-        seatData = snap.docs.map(d => ({ id: d.id, ...d.data() }));
+      onSnapshot(query(seatsRef, orderBy('seatIndex', 'asc')), (snap) => {
+        seatData = snap.docs.map((d) => ({ id: d.id, ...d.data() }));
         showSeatsDebug(tableId, snap.docs);
         renderSeats();
         renderHand();
+        renderTableInfo();
         updateDebug();
       });
     }
@@ -92,16 +93,19 @@
       const t = tableData;
       const blindStr = `${dollars(t.smallBlindCents || 0)}/${dollars(t.bigBlindCents || 0)}`;
       const rangeStr = `${dollars(t.minBuyInCents || 0)}–${dollars(t.maxBuyInCents || 0)} (default ${dollars(t.defaultBuyInCents || 0)})`;
+      const derivedSeatCount = seatData.filter(s => s.occupiedBy).length;
+      const activeSeatCount = t.activeSeatCount ?? 0;
       infoEl.innerHTML = `
         <h1>${t.name || '(no name)'}</h1>
         <div class="small">Blinds: ${blindStr}</div>
         <div class="small">Buy-in: ${rangeStr}</div>
+        <div class="small">Players seated: ${derivedSeatCount} (active: ${activeSeatCount})</div>
       `;
     }
 
     function renderHand() {
       if (!handData) {
-        const seatCount = seatData.filter(s => s.active).length;
+        const seatCount = seatData.filter(s => s.occupiedBy).length;
         handEl.innerHTML = seatCount < 2 ? 'Waiting for players…' : 'Waiting for next dealer’s choice…';
         actionEl.style.display = 'none';
         return;
@@ -114,7 +118,7 @@
       const h = handData;
       const vLabel = h.variant === 'omaha' ? 'Omaha' : "Hold'em";
       const stageStr = stageLabel(h);
-      const getNameBySeat = (n) => seatData.find(s => s.seatNum === n)?.playerName || '(left)';
+      const getNameBySeat = (n) => seatData.find(s => s.seatIndex === n)?.displayName || '(left)';
       const dealerName = h.dealerName || getNameBySeat(h.positions?.dealerSeatNum);
       const sbName = getNameBySeat(h.positions?.sbSeatNum);
       const bbName = getNameBySeat(h.positions?.bbSeatNum);
@@ -124,7 +128,7 @@
       if (h.contributions) {
         const parts = [];
         for (const [pid, cents] of Object.entries(h.contributions)) {
-          const name = seatData.find(s => s.playerId === pid)?.playerName || '(left)';
+          const name = seatData.find(s => s.occupiedBy === pid)?.displayName || '(left)';
           parts.push(`${name}: ${dollars(cents)}`);
         }
         if (parts.length) contrib = `<div class="small">${parts.join(', ')}</div>`;
@@ -149,7 +153,9 @@
     }
 
     function renderSeats() {
-      const rows = seatData.map(s => `<div>${s.playerName || '(no name)'} • ${dollars(s.chipStackCents || 0)}</div>`);
+      const rows = seatData
+        .filter((s) => s.occupiedBy)
+        .map((s) => `<div>${s.displayName || '(no name)'} • ${dollars(s.stackCents || 0)}</div>`);
       seatsEl.innerHTML = `<h2 style="margin-top:0;">Seats</h2>${rows.join('') || '<div class="small">(none yet)</div>'}`;
     }
 
@@ -158,8 +164,8 @@
       const current = getCurrentPlayer();
       if (!handData || !current) { actionEl.style.display = 'none'; return; }
       const folded = handData.folded || {};
-      const currentSeat = seatData.find(s => s.playerId === current.id);
-      const isActor = currentSeat && currentSeat.seatNum === handData.actorSeatNum && !folded[current.id] && (currentSeat.chipStackCents > 0);
+      const currentSeat = seatData.find(s => s.occupiedBy === current.id);
+      const isActor = currentSeat && currentSeat.seatIndex === handData.actorSeatNum && !folded[current.id] && (currentSeat.stackCents > 0);
       if (!isActor) { actionEl.style.display = 'none'; return; }
 
       const toCall = handData.toCallCents || 0;


### PR DESCRIPTION
## Summary
- add maxSeats and activeSeatCount metadata to tables and create empty seat docs
- join/leave seats with Firestore transactions and maintain activeSeatCount
- allow archiving tables instead of hard delete and track seated players in table view

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c4c5e1ebb4832ebcaab0c1133e4c50