### PR TITLE
Use chipStackCents for seat display and actor logic

### DIFF
--- a/public/lobby.html
+++ b/public/lobby.html
@@ -161,7 +161,7 @@
           seatSnap.forEach((s) => {
             const sd = s.data();
             if (sd.occupiedBy) {
-              seated.push(`<div style=\\"display:flex;justify-content:space-between;\\"><span>${sd.displayName || sd.occupiedBy}</span><span>${dollars(sd.stackCents || 0)}</span></div>`);
+              seated.push(`<div style=\\"display:flex;justify-content:space-between;\\"><span>${sd.displayName || sd.occupiedBy}</span><span>${dollars(sd.chipStackCents || 0)}</span></div>`);
               seatMap.push({ seatNum: sd.seatIndex, playerName: sd.displayName || sd.occupiedBy });
               activeCount++;
             }
@@ -332,7 +332,7 @@
 
             const p = playerSnap.data() || {};
             const s = seatSnap.data();
-            const newWallet = (p.walletCents || 0) + (s.stackCents || 0);
+            const newWallet = (p.walletCents || 0) + (s.chipStackCents || 0);
 
             tx.update(playerRef, { walletCents: newWallet });
             tx.update(seatRef, {

--- a/public/table.html
+++ b/public/table.html
@@ -171,7 +171,7 @@
     function renderSeats() {
       const rows = seatData
         .filter((s) => s.occupiedBy)
-        .map((s) => `<div>${s.displayName || '(no name)'} • ${dollars(s.stackCents || 0)}</div>`);
+        .map((s) => `<div>${s.displayName || '(no name)'} • ${dollars(s.chipStackCents || 0)}</div>`);
       seatsEl.innerHTML = `<h2 style="margin-top:0;">Seats</h2>${rows.join('') || '<div class="small">(none yet)</div>'}`;
     }
 
@@ -186,7 +186,7 @@
         return;
       }
       const folded = handData?.folded || {};
-      const isActor = handData && seat.seatIndex === handData.actorSeatNum && !folded[current.id] && (seat.stackCents > 0);
+      const isActor = handData && seat.seatIndex === handData.actorSeatNum && !folded[current.id] && (seat.chipStackCents > 0);
       const toCall = handData?.toCallCents || 0;
       const minRaise = handData?.minRaiseCents || 0;
       const callLabel = toCall > 0 ? `Call ${dollars(toCall)}` : 'Check';


### PR DESCRIPTION
## Summary
- display seat chip counts using chipStackCents
- base actor status on chipStackCents instead of stackCents
- continue writing stackCents and chipStackCents during seat join/leave

## Testing
- `npm --prefix functions run build`

------
https://chatgpt.com/codex/tasks/task_e_68c5d17eed2c832e96671eb56f8e39d0