### PR TITLE
Delete seats on leave to avoid updates

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -23,10 +23,9 @@ service cloud.firestore {
     match /tables/{tableId}/seats/{playerId} {
       allow read: if true;
 
-      // Join / Leave from client is okay; server manages chip counts afterwards.
+      // Seats are created when a player joins and removed when they leave.
+      // Chip stacks and seat numbers are managed by the server, so updates are blocked.
       allow create, delete: if true;
-
-      // Prevent clients from editing chip stacks, seatNum, etc.
       allow update: if false;
     }
 

--- a/public/lobby.html
+++ b/public/lobby.html
@@ -335,17 +335,7 @@
             const newWallet = (p.walletCents || 0) + (s.stackCents || 0);
 
             tx.update(playerRef, { walletCents: newWallet });
-            tx.update(seatRef, {
-              occupiedBy: null,
-              playerId: null,
-              displayName: null,
-              playerName: null,
-              sittingOut: false,
-              stackCents: null,
-              chipStackCents: null,
-              updatedAt: serverTimestamp(),
-              active: false,
-            });
+            tx.delete(seatRef);
             tx.update(tableRef, { activeSeatCount: increment(-1) });
           });
           alert("You left the table. Chips returned to wallet.");


### PR DESCRIPTION
## Summary
- Remove seat update on leave and delete seat document instead
- Clarify Firestore rules that seats are created/deleted and not updated

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c5d1808074832eb8fc8b0b6dfce131