### PR TITLE
Restrict table reads to active tables

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -9,7 +9,8 @@ service cloud.firestore {
 
     match /tables/{tableId} {
       // Players may read only active tables.
-      allow read: if resource.data.active == true;
+      allow get: if resource.data.active == true;
+      allow list: if request.query.active == true;
 
       // Allow creating/deleting tables from Admin UI (dev phase).
       allow create, delete: if true;


### PR DESCRIPTION
## Summary
- split table read rules into distinct get and list checks

## Testing
- `npm test` *(fails: ENOENT)*
- `firebase deploy --only firestore:rules` *(fails: command not found)*
- `npm install -g firebase-tools` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c5d738f898832eb2d32de94405308e