### PR TITLE
Allow players to update their own seat

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -24,9 +24,13 @@ service cloud.firestore {
       allow read: if true;
 
       // Seats are created when a player joins and removed when they leave.
-      // Chip stacks and seat numbers are managed by the server, so updates are blocked.
+      // Chip stacks and seat numbers are managed by the server, so updates
+      // are only allowed when the player is updating their own seat record.
       allow create, delete: if true;
-      allow update: if false;
+      allow update: if
+        request.auth != null &&
+        request.auth.uid == request.resource.data.occupiedBy &&
+        request.auth.uid == request.resource.data.playerId;
     }
 
     // Hands are server-managed only.


### PR DESCRIPTION
## Summary
- permit seat updates only when the requester matches `occupiedBy`/`playerId`

## Testing
- `firebase deploy --only firestore:rules` *(fails: command not found)*
- `node -e "require('firebase')"` *(fails: Cannot find module 'firebase')*

------
https://chatgpt.com/codex/tasks/task_e_68c5d739eaec832e9bc09d4297b21c1e