### PR TITLE
Use read rule for active tables

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -9,8 +9,7 @@ service cloud.firestore {
 
     match /tables/{tableId} {
       // Players may read only active tables.
-      allow get: if resource.data.active == true;
-      allow list: if request.query.active == true;
+      allow read: if resource.data.active == true;
 
       // Allow creating/deleting tables from Admin UI (dev phase).
       allow create, delete: if true;


### PR DESCRIPTION
## Summary
- Replace `get`/`list` table rules with a single `read` rule that checks `active`

## Testing
- `firebase deploy --only firestore:rules` *(fails: command not found)*
- `npm install -g firebase-tools` *(fails: 403 Forbidden)*


------
https://chatgpt.com/codex/tasks/task_e_68c5d9b98dc0832ea5223e7d8cd1ede9