### PR TITLE
11c hotfix: index fallback + table create schema + rules for activeSeatCount

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -15,7 +15,7 @@ service cloud.firestore {
       allow create, delete: if true;
 
       // Allow client to change nextVariantId, or admin to archive.
-      allow update: if request.resource.data.diff(resource.data).changedKeys().hasOnly(['nextVariantId']) ||
+      allow update: if request.resource.data.diff(resource.data).changedKeys().hasOnly(['nextVariantId','activeSeatCount']) ||
         (request.resource.data.diff(resource.data).changedKeys().hasOnly(['active', 'deletedAt']) &&
          resource.data.active == true && request.resource.data.active == false);
     }

--- a/public/admin.html
+++ b/public/admin.html
@@ -201,16 +201,13 @@
       try {
         const tableRef = await addDoc(tablesCol, {
           name,
-          minBuyInCents: minC,
-          maxBuyInCents: maxC,
-          defaultBuyInCents: defC,
-          smallBlindCents: sbC,
-          bigBlindCents: bbC,
+          active: true,
+          createdAt: serverTimestamp(),
           maxSeats: 6,
           activeSeatCount: 0,
-          active: true,
-          deletedAt: null,
-          createdAt: serverTimestamp(),
+          gameType: 'holdem',
+          blinds: { sbCents: sbC, bbCents: bbC },
+          buyIn: { minCents: minC, maxCents: maxC, defaultCents: defC },
         });
         const seatsCol = collection(tableRef, "seats");
         for (let i = 0; i < 6; i++) {
@@ -251,11 +248,18 @@
     const seatCounts = {};
     const seatUnsubs = {};
     const renderTables = () => {
-      const rows = Object.entries(tablesData).map(([id, d]) => {
-        const blindStr = `${dollars(d.smallBlindCents || 0)}/${dollars(d.bigBlindCents || 0)}`;
-        const rangeStr = `${dollars(d.minBuyInCents || 0)}–${dollars(d.maxBuyInCents || 0)} (${dollars(d.defaultBuyInCents || 0)})`;
-        const seated = seatCounts[id] || 0;
-        return `<tr data-id="${id}">
+      const rows = Object.entries(tablesData)
+        .sort((a, b) => (b[1].createdAt?.toMillis?.() || 0) - (a[1].createdAt?.toMillis?.() || 0))
+        .map(([id, d]) => {
+          const sb = d?.blinds?.sbCents ?? d.smallBlindCents ?? 0;
+          const bb = d?.blinds?.bbCents ?? d.bigBlindCents ?? 0;
+          const minB = d?.buyIn?.minCents ?? d.minBuyInCents ?? 0;
+          const maxB = d?.buyIn?.maxCents ?? d.maxBuyInCents ?? 0;
+          const defB = d?.buyIn?.defaultCents ?? d.defaultBuyInCents ?? 0;
+          const blindStr = `${dollars(sb)}/${dollars(bb)}`;
+          const rangeStr = `${dollars(minB)}–${dollars(maxB)} (${dollars(defB)})`;
+          const seated = seatCounts[id] || 0;
+          return `<tr data-id="${id}">
           <td style="padding:8px;border-bottom:1px solid #334155;"><div style="font-weight:600">${d.name || "(no name)"}</div><div class="small"><code>${id}</code></div></td>
           <td style="padding:8px;border-bottom:1px solid #334155;">${blindStr}</td>
           <td style="padding:8px;border-bottom:1px solid #334155;">${rangeStr}</td>
@@ -265,7 +269,7 @@
             <button class="archive-table" style="padding:4px 8px;border-radius:8px;border:1px solid #7f1d1d;background:#ef4444;color:white;font-size:12px;cursor:pointer;">Archive</button>
           </td>
         </tr>`;
-      });
+        });
       if (rows.length === 0) {
         tablesBody.innerHTML = `<tr><td colspan="5" style="padding:8px;">No tables yet.</td></tr>`;
       } else {
@@ -273,9 +277,11 @@
       }
     };
 
-    onSnapshot(
-      query(tablesCol, where("active", "==", true), orderBy("createdAt", "desc")),
-      (snap) => {
+    function startTablesListener(useFallback = false) {
+      const q = useFallback
+        ? query(tablesCol, where("active", "==", true))
+        : query(tablesCol, where("active", "==", true), orderBy("createdAt", "desc"));
+      onSnapshot(q, (snap) => {
         snap.docChanges().forEach((change) => {
           const id = change.doc.id;
           if (change.type === "removed") {
@@ -300,17 +306,23 @@
           }
         });
         renderTables();
-      },
-      (err) => {
-        const loadingEl = document.getElementById("tables-loading");
-        if (loadingEl) {
-          const msg = err?.code === "permission-denied"
-            ? "Cannot load tables: permission denied."
-            : "Error loading tables: " + (err?.message || err);
-          loadingEl.textContent = msg;
+      }, (err) => {
+        if (err.code === "failed-precondition" && !useFallback) {
+          console.warn('admin.tables.fallback.index_missing');
+          startTablesListener(true);
+        } else {
+          const loadingEl = document.getElementById("tables-loading");
+          if (loadingEl) {
+            const msg = err?.code === "permission-denied"
+              ? "Cannot load tables: permission denied."
+              : "Error loading tables: " + (err?.message || err);
+            loadingEl.textContent = msg;
+          }
         }
-      }
-    );
+      });
+    }
+
+    startTablesListener();
 
     tablesBody?.addEventListener("click", async (e) => {
       if (!e.target.classList.contains("archive-table")) return;

--- a/public/lobby.html
+++ b/public/lobby.html
@@ -44,8 +44,13 @@
     const handUnsubs = new Map();
 
     const renderTable = (id, d, seatsHtml, seatCount, hand, seatMap) => {
-      const blindStr = `${dollars(d.smallBlindCents || 0)}/${dollars(d.bigBlindCents || 0)}`;
-      const rangeStr = `${dollars(d.minBuyInCents || 0)}–${dollars(d.maxBuyInCents || 0)} (default ${dollars(d.defaultBuyInCents || 0)})`;
+      const sb = d?.blinds?.sbCents ?? d.smallBlindCents ?? 0;
+      const bb = d?.blinds?.bbCents ?? d.bigBlindCents ?? 0;
+      const minB = d?.buyIn?.minCents ?? d.minBuyInCents ?? 0;
+      const maxB = d?.buyIn?.maxCents ?? d.maxBuyInCents ?? 0;
+      const defB = d?.buyIn?.defaultCents ?? d.defaultBuyInCents ?? 0;
+      const blindStr = `${dollars(sb)}/${dollars(bb)}`;
+      const rangeStr = `${dollars(minB)}–${dollars(maxB)} (default ${dollars(defB)})`;
       let banner;
       let potLine = "";
       let stageLine = "";
@@ -84,7 +89,7 @@
             <div>
               <div style="font-weight:700">${d.name || "(no name)"}</div>
               <div class="small">Code: <code>${id}</code></div>
-              <div class="small">Seats: ${d.activeSeatCount || 0} / ${d.maxSeats || 0}</div>
+              <div class="small">Seats: ${seatCount === null ? (d.activeSeatCount || 0) : `${seatCount} (active: ${d.activeSeatCount || 0})`} / ${d.maxSeats || 0}</div>
               <div class="small">Blinds: ${blindStr}</div>
               <div class="small">Buy-in: ${rangeStr}</div>
               <div class="small" style="margin-top:4px;">${banner}</div>
@@ -135,66 +140,78 @@
       blocks.forEach(updateDebug);
     };
 
-    const q = query(tablesCol, where('active', '==', true), orderBy('createdAt', 'desc'));
-    debugLog('lobby.query.started');
-    onSnapshot(q, (snap) => {
-      debugLog('lobby.tablesSnapshot', snap.size);
-      blocks = [];
-      seatUnsubs.forEach(u => u());
-      seatUnsubs.clear();
-      handUnsubs.forEach(u => u());
-      handUnsubs.clear();
+    function startTablesListener(useFallback = false) {
+      const q = useFallback
+        ? query(tablesCol, where('active', '==', true))
+        : query(tablesCol, where('active', '==', true), orderBy('createdAt', 'desc'));
+      debugLog(useFallback ? 'lobby.query.started.fallback' : 'lobby.query.started');
+      onSnapshot(q, (snap) => {
+        debugLog('lobby.tablesSnapshot', snap.size);
+        blocks = [];
+        seatUnsubs.forEach(u => u());
+        seatUnsubs.clear();
+        handUnsubs.forEach(u => u());
+        handUnsubs.clear();
 
-      if (snap.empty) debugLog('lobby.query.empty (0 docs)');
-      else debugLog('lobby.query.ok', { count: snap.size });
+        const docs = [...snap.docs].sort((a,b) => (b.data()?.createdAt?.toMillis?.() || 0) - (a.data()?.createdAt?.toMillis?.() || 0));
+        if (snap.empty) debugLog('lobby.query.empty (0 docs)');
+        else debugLog('lobby.query.ok', { count: snap.size });
 
-      snap.forEach(docSnap => {
-        const id = docSnap.id;
-        const d = docSnap.data();
-        blocks.push({ id, data: d, seatsHtml: "Loading…", seatCount: 0, hand: null, seatMap: [] });
-        const seatsRef = subcol(doc(db, "tables", id), "seats");
-        const unsubSeats = onSnapshot(seatsRef, (seatSnap) => {
-          debugLog('lobby.seatsSnapshot', id, seatSnap.size);
-          const seated = [];
-          const seatMap = [];
-          let activeCount = 0;
-          seatSnap.forEach((s) => {
-            const sd = s.data();
-            if (sd.occupiedBy) {
-              seated.push(`<div style=\\"display:flex;justify-content:space-between;\\"><span>${sd.displayName || sd.occupiedBy}</span><span>${dollars(sd.chipStackCents || 0)}</span></div>`);
-              seatMap.push({ seatNum: sd.seatIndex, playerName: sd.displayName || sd.occupiedBy });
-              activeCount++;
-            }
-          });
-          const idx = blocks.findIndex((b) => b.id === id);
-          if (idx >= 0) {
-            blocks[idx].seatsHtml = seated.join("") || "(none yet)";
-            blocks[idx].seatCount = activeCount;
-            blocks[idx].seatMap = seatMap;
-            renderAll();
-          }
-        });
-        seatUnsubs.set(id, unsubSeats);
-
-        if (d.currentHandId) {
-          const handRef = doc(db, "tables", id, "hands", d.currentHandId);
-          const unsubHand = onSnapshot(handRef, (handSnap) => {
-            const idx = blocks.findIndex(b => b.id === id);
+        docs.forEach(docSnap => {
+          const id = docSnap.id;
+          const d = docSnap.data();
+          blocks.push({ id, data: d, seatsHtml: "Loading…", seatCount: null, hand: null, seatMap: [] });
+          const seatsRef = subcol(doc(db, "tables", id), "seats");
+          const unsubSeats = onSnapshot(seatsRef, (seatSnap) => {
+            debugLog('lobby.seatsSnapshot', id, seatSnap.size);
+            const seated = [];
+            const seatMap = [];
+            let activeCount = 0;
+            seatSnap.forEach((s) => {
+              const sd = s.data();
+              if (sd.occupiedBy) {
+                seated.push(`<div style=\\"display:flex;justify-content:space-between;\\"><span>${sd.displayName || sd.occupiedBy}</span><span>${dollars(sd.chipStackCents || 0)}</span></div>`);
+                seatMap.push({ seatNum: sd.seatIndex, playerName: sd.displayName || sd.occupiedBy });
+                activeCount++;
+              }
+            });
+            const idx = blocks.findIndex((b) => b.id === id);
             if (idx >= 0) {
-              blocks[idx].hand = handSnap.data();
+              blocks[idx].seatsHtml = seated.join("") || "(none yet)";
+              blocks[idx].seatCount = activeCount;
+              blocks[idx].seatMap = seatMap;
               renderAll();
             }
           });
-          handUnsubs.set(id, unsubHand);
+          seatUnsubs.set(id, unsubSeats);
+
+          if (d.currentHandId) {
+            const handRef = doc(db, "tables", id, "hands", d.currentHandId);
+            const unsubHand = onSnapshot(handRef, (handSnap) => {
+              const idx = blocks.findIndex(b => b.id === id);
+              if (idx >= 0) {
+                blocks[idx].hand = handSnap.data();
+                renderAll();
+              }
+            });
+            handUnsubs.set(id, unsubHand);
+          }
+        });
+
+        renderAll();
+      }, (err) => {
+        if (err.code === 'failed-precondition' && !useFallback) {
+          debugLog('lobby.query.fallback.index_missing');
+          startTablesListener(true);
+        } else {
+          if (err.code === 'permission-denied') debugLog('lobby.query.permissionDenied');
+          else debugLog('lobby.query.error', err);
+          listEl.textContent = err.code === 'permission-denied' ? 'Cannot load tables: permission denied.' : 'Error loading tables.';
         }
       });
+    }
 
-      renderAll();
-    }, (err) => {
-      if (err.code === 'permission-denied') debugLog('lobby.query.permissionDenied');
-      else if (err.code === 'failed-precondition') debugLog('lobby.query.indexError');
-      else debugLog('lobby.query.error', err);
-    });
+    startTablesListener();
 
     // re-render when current player changes
     document.addEventListener('change', (e) => {
@@ -224,8 +241,10 @@
 
         const t = tableSnap.data();
         const p = playerSnap.data();
+        const minB = t?.buyIn?.minCents ?? t.minBuyInCents ?? 0;
+        const maxB = t?.buyIn?.maxCents ?? t.maxBuyInCents ?? 0;
 
-        if (amountCents < (t.minBuyInCents || 0) || amountCents > (t.maxBuyInCents || 0))
+        if (amountCents < minB || amountCents > maxB)
           throw new Error("Amount must be between min and max buy-in.");
         if ((p.walletCents || 0) < amountCents)
           throw new Error("Not enough wallet balance.");
@@ -280,8 +299,9 @@
         // prefill default from table
         const tableSnap = await getDoc(doc(db, "tables", id));
         const t = tableSnap.data();
+        const def = t?.buyIn?.defaultCents ?? t.defaultBuyInCents ?? 0;
         const input = document.getElementById(`amount-${id}`);
-        input.value = (t?.defaultBuyInCents ? (t.defaultBuyInCents/100).toFixed(2) : "0.00");
+        input.value = (def/100).toFixed(2);
         panel.style.display = "block";
         return;
       }

--- a/public/table.html
+++ b/public/table.html
@@ -107,15 +107,20 @@
     function renderTableInfo() {
       if (!tableData) { infoEl.textContent = ''; return; }
       const t = tableData;
-      const blindStr = `${dollars(t.smallBlindCents || 0)}/${dollars(t.bigBlindCents || 0)}`;
-      const rangeStr = `${dollars(t.minBuyInCents || 0)}–${dollars(t.maxBuyInCents || 0)} (default ${dollars(t.defaultBuyInCents || 0)})`;
+      const sb = t?.blinds?.sbCents ?? t.smallBlindCents ?? 0;
+      const bb = t?.blinds?.bbCents ?? t.bigBlindCents ?? 0;
+      const minB = t?.buyIn?.minCents ?? t.minBuyInCents ?? 0;
+      const maxB = t?.buyIn?.maxCents ?? t.maxBuyInCents ?? 0;
+      const defB = t?.buyIn?.defaultCents ?? t.defaultBuyInCents ?? 0;
+      const blindStr = `${dollars(sb)}/${dollars(bb)}`;
+      const rangeStr = `${dollars(minB)}–${dollars(maxB)} (default ${dollars(defB)})`;
       const derivedSeatCount = seatData.filter(s => s.occupiedBy).length;
       const activeSeatCount = t.activeSeatCount ?? 0;
       infoEl.innerHTML = `
         <h1>${t.name || '(no name)'}</h1>
         <div class="small">Blinds: ${blindStr}</div>
         <div class="small">Buy-in: ${rangeStr}</div>
-        <div class="small">Players seated: ${derivedSeatCount} (active: ${activeSeatCount})</div>
+        <div class="small">Seats: ${derivedSeatCount} (active: ${activeSeatCount}) / ${t.maxSeats || 0}</div>
       `;
     }
 


### PR DESCRIPTION
## Summary
- add client-side fallback queries when index is missing and sort results by createdAt
- write new tables with spec-compliant blinds and buy-in objects and show derived vs active seat counts
- allow activeSeatCount updates in Firestore rules

## Testing
- `npm test` *(fails: package.json not found)*
- `(cd functions && npm test)` *(fails: Missing script "test")*
- `(cd functions && npm run build)`

------
https://chatgpt.com/codex/tasks/task_e_68c5e9306ea0832e82194d667ea62dd2