### PR TITLE
11c hotfix: anon auth + narrow rules to allow seat join

### DIFF
--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -15,6 +15,7 @@
 - **Preflop skeleton** (fold, check/call, min-raise; server-validated; ends hand after round)
 - **Streets engine** merged: preflop→flop→turn→river + board, but UI render depends on table wiring (see “Open Issues”)
 - **brief-11c.hotfix-2** complete — lobby visibility, join flow, player board
+- **brief-11c.hotfix-4** complete — anon auth + join permissions
 
 ## Open Issues / Next Steps
 - Verify **Board UI** renders in /table.html after closing preflop.

--- a/firestore.rules
+++ b/firestore.rules
@@ -2,6 +2,10 @@ rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
 
+    function isAdmin() {
+      return request.auth != null && request.auth.token.admin == true;
+    }
+
     // DEV: players are open until Auth is added.
     match /players/{playerId} {
       allow read, write: if true;
@@ -11,26 +15,27 @@ service cloud.firestore {
       // Players may read only active tables.
       allow read: if resource.data.active == true;
 
-      // Allow creating/deleting tables from Admin UI (dev phase).
-      allow create, delete: if true;
+      // Admin keeps create & destructive updates
+      allow create, delete: if isAdmin();
 
-      // Allow client to change nextVariantId, or admin to archive.
-      allow update: if request.resource.data.diff(resource.data).changedKeys().hasOnly(['nextVariantId','activeSeatCount']) ||
-        (request.resource.data.diff(resource.data).changedKeys().hasOnly(['active', 'deletedAt']) &&
-         resource.data.active == true && request.resource.data.active == false);
-    }
+      // Allow players (anon auth) to update ONLY activeSeatCount
+      allow update: if (request.auth != null &&
+        request.resource.data.diff(resource.data).changedKeys().hasOnly(['activeSeatCount']))
+        || isAdmin();
 
-    match /tables/{tableId}/seats/{playerId} {
-      allow read: if true;
+      match /seats/{seatId} {
+        allow read: if true;
 
-      // Seats are created when a player joins and removed when they leave.
-      // Chip stacks and seat numbers are managed by the server, so updates
-      // are only allowed when the player is updating their own seat record.
-      allow create, delete: if true;
-      allow update: if
-        request.auth != null &&
-        request.auth.uid == request.resource.data.occupiedBy &&
-        request.auth.uid == request.resource.data.playerId;
+        // Allow players (anon auth) to claim/leave seats with limited fields only
+        allow create, update: if request.auth != null &&
+          request.resource.data.diff(resource.data).changedKeys().subsetOf([
+            'seatIndex','seatNum','occupiedBy','playerId','playerName','displayName',
+            'sittingOut','stackCents','chipStackCents','updatedAt','active'
+          ]) &&
+          (!resource.exists || request.resource.data.seatIndex == resource.data.seatIndex);
+        // No deletes by players
+        allow delete: if false;
+      }
     }
 
     // Hands are server-managed only.

--- a/public/admin.html
+++ b/public/admin.html
@@ -91,11 +91,19 @@
 
   <script type="module" src="/firebase-init.js"></script>
   <script type="module">
+    import { app } from "/firebase-init.js";
     import { db, dollars, parseDollarsToCents, renderCurrentPlayerControls } from "/common.js";
     import {
       collection, addDoc, serverTimestamp, query, orderBy, onSnapshot, where,
       doc, updateDoc, deleteDoc, setDoc
     } from "https://www.gstatic.com/firebasejs/10.12.5/firebase-firestore.js";
+    import { getAuth, onAuthStateChanged, signInAnonymously } from "https://www.gstatic.com/firebasejs/10.12.5/firebase-auth.js";
+
+    const auth = getAuth(app);
+    onAuthStateChanged(auth, (u) => {
+      if (u) console.log(`auth.anon.ready: uid=${u.uid}`);
+      else signInAnonymously(auth).catch(console.error);
+    });
 
     renderCurrentPlayerControls("you");
 

--- a/public/lobby.html
+++ b/public/lobby.html
@@ -26,11 +26,19 @@
 
   <script type="module" src="/firebase-init.js"></script>
   <script type="module">
+    import { app } from "/firebase-init.js";
     import { db, dollars, parseDollarsToCents, getCurrentPlayer, renderCurrentPlayerControls, isDebug, setDebug, formatCard, stageLabel, debugLog } from "/common.js";
     import {
       collection, query, orderBy, where, onSnapshot, doc, collection as subcol,
       runTransaction, serverTimestamp, increment, getDoc, updateDoc
     } from "https://www.gstatic.com/firebasejs/10.12.5/firebase-firestore.js";
+    import { getAuth, onAuthStateChanged, signInAnonymously } from "https://www.gstatic.com/firebasejs/10.12.5/firebase-auth.js";
+
+    const auth = getAuth(app);
+    onAuthStateChanged(auth, (u) => {
+      if (u) console.log(`auth.anon.ready: uid=${u.uid}`);
+      else signInAnonymously(auth).catch(console.error);
+    });
 
     renderCurrentPlayerControls("you");
     const debugChip = document.getElementById('debug-chip');
@@ -228,12 +236,14 @@
     });
 
     async function joinTable(tableId, cp, amountCents) {
-      await runTransaction(db, async (tx) => {
-        const tableRef = doc(db, "tables", tableId);
-        const playerRef = doc(db, "players", cp.id);
+      let seatIndex = -1;
+      try {
+        await runTransaction(db, async (tx) => {
+          const tableRef = doc(db, "tables", tableId);
+          const playerRef = doc(db, "players", cp.id);
 
-        const [tableSnap, playerSnap] = await Promise.all([
-          tx.get(tableRef),
+          const [tableSnap, playerSnap] = await Promise.all([
+            tx.get(tableRef),
           tx.get(playerRef),
         ]);
         if (!tableSnap.exists()) throw new Error("Table not found.");
@@ -268,22 +278,31 @@
         }
         if (!seatRef) throw new Error("No available seats.");
 
-        tx.update(playerRef, { walletCents: (p.walletCents || 0) - amountCents });
-        tx.set(seatRef, {
-          seatIndex,
-          seatNum: seatIndex,
-          occupiedBy: cp.id,
-          playerId: cp.id,
-          displayName: cp.name || p.name || "",
-          playerName: cp.name || p.name || "",
-          sittingOut: false,
-          stackCents: amountCents,
-          chipStackCents: amountCents,
-          updatedAt: serverTimestamp(),
-          active: true,
+          tx.update(playerRef, { walletCents: (p.walletCents || 0) - amountCents });
+          tx.set(seatRef, {
+            seatIndex,
+            seatNum: seatIndex,
+            occupiedBy: cp.id,
+            playerId: cp.id,
+            displayName: cp.name || p.name || "",
+            playerName: cp.name || p.name || "",
+            sittingOut: false,
+            stackCents: amountCents,
+            chipStackCents: amountCents,
+            updatedAt: serverTimestamp(),
+            active: true,
+          });
+          tx.update(tableRef, { activeSeatCount: increment(1) });
         });
-        tx.update(tableRef, { activeSeatCount: increment(1) });
-      });
+        debugLog('seat.tx.claim.ok', { seatIndex, uid: cp.id });
+      } catch (err) {
+        debugLog('seat.tx.claim.fail', { code: err?.code });
+        const msg = err?.code === 'permission-denied'
+          ? "You're not signed in. Try again in 2s."
+          : "Seat taken—try another.";
+        alert(msg);
+        throw err;
+      }
     }
 
     // Click handlers (join/leave)
@@ -318,7 +337,7 @@
           await joinTable(tableId, cp, amountCents);
           status.textContent = "Joined ✔";
         } catch (err) {
-          status.textContent = "Error: " + (err?.message || err);
+          status.textContent = "Error joining";
         }
         return;
       }
@@ -355,12 +374,27 @@
             const newWallet = (p.walletCents || 0) + (s.chipStackCents || 0);
 
             tx.update(playerRef, { walletCents: newWallet });
-            tx.delete(seatRef);
+            tx.update(seatRef, {
+              occupiedBy: null,
+              playerId: null,
+              playerName: null,
+              displayName: '',
+              sittingOut: false,
+              stackCents: 0,
+              chipStackCents: 0,
+              updatedAt: serverTimestamp(),
+              active: false,
+            });
             tx.update(tableRef, { activeSeatCount: increment(-1) });
           });
           alert("You left the table. Chips returned to wallet.");
+          debugLog('seat.tx.leave.ok');
         } catch (err) {
-          alert("Error: " + (err?.message || err));
+          debugLog('seat.tx.leave.fail', { code: err?.code });
+          const msg = err?.code === 'permission-denied'
+            ? "You're not signed in. Try again in 2s."
+            : "Error leaving seat.";
+          alert(msg);
         }
         return;
       }

--- a/public/table.html
+++ b/public/table.html
@@ -24,10 +24,18 @@
 
   <script type="module" src="/firebase-init.js"></script>
   <script type="module">
+    import { app } from "/firebase-init.js";
     import { db, dollars, renderCurrentPlayerControls, isDebug, setDebug, getCurrentPlayer, formatCard, stageLabel, showSeatsDebug, debugLog } from "/common.js";
     import {
       doc, onSnapshot, collection, query, orderBy, addDoc, serverTimestamp
     } from "https://www.gstatic.com/firebasejs/10.12.5/firebase-firestore.js";
+    import { getAuth, onAuthStateChanged, signInAnonymously } from "https://www.gstatic.com/firebasejs/10.12.5/firebase-auth.js";
+
+    const auth = getAuth(app);
+    onAuthStateChanged(auth, (u) => {
+      if (u) console.log(`auth.anon.ready: uid=${u.uid}`);
+      else signInAnonymously(auth).catch(console.error);
+    });
 
     renderCurrentPlayerControls("you");
     const debugChip = document.getElementById('debug-chip');


### PR DESCRIPTION
## Summary
- enable anonymous authentication on player-facing pages
- allow activeSeatCount and seat field updates through narrowed Firestore rules
- add transaction logging and error handling for seat join/leave flows

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68c5ec86ab18832e9bf15fef1ce6f64b