### PR TITLE
11c hotfix: await anon auth for Admin create + clearer errors

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -97,24 +97,38 @@
       collection, addDoc, serverTimestamp, query, orderBy, onSnapshot, where,
       doc, updateDoc, deleteDoc, setDoc
     } from "https://www.gstatic.com/firebasejs/10.12.5/firebase-firestore.js";
-    import { getAuth, onAuthStateChanged, signInAnonymously } from "https://www.gstatic.com/firebasejs/10.12.5/firebase-auth.js";
-
-    const auth = getAuth(app);
-    onAuthStateChanged(auth, (u) => {
-      if (u) console.log(`auth.anon.ready: uid=${u.uid}`);
-      else signInAnonymously(auth).catch(console.error);
-    });
+    import { awaitAuthReady, isAuthed } from "/auth.js";
 
     renderCurrentPlayerControls("you");
 
-    // ----- players (same behavior as before) -----
+    // ----- players / tables shared auth gate -----
     const playersCol = collection(db, "players");
     const addBtn = document.getElementById("add-player");
     const nameInput = document.getElementById("player-name");
     const statusEl = document.getElementById("add-status");
     const listEl = document.getElementById("players-list");
 
+    const tablesCol = collection(db, "tables");
+    const tName = document.getElementById("table-name");
+    const tMin = document.getElementById("min-buyin");
+    const tDef = document.getElementById("default-buyin");
+    const tMax = document.getElementById("max-buyin");
+    const tSB  = document.getElementById("sb");
+    const tBB  = document.getElementById("bb");
+    const tBtn = document.getElementById("create-table");
+    const tStatus = document.getElementById("table-status");
+
+    addBtn.disabled = true;
+    tBtn.disabled = true;
+    statusEl.textContent = tStatus.textContent = "Signing in…";
+    await awaitAuthReady();
+    addBtn.disabled = false;
+    tBtn.disabled = false;
+    statusEl.textContent = "";
+    tStatus.textContent = "";
+
     addBtn?.addEventListener("click", async () => {
+      if (!isAuthed()) { statusEl.textContent = "Auth not ready"; setTimeout(() => (statusEl.textContent = ""), 2000); return; }
       const name = (nameInput.value || "").trim();
       if (!name) { statusEl.textContent = "Please enter a name."; return; }
       statusEl.textContent = "Saving…";
@@ -179,17 +193,12 @@
     });
 
     // ----- tables -----
-    const tablesCol = collection(db, "tables");
-    const tName = document.getElementById("table-name");
-    const tMin = document.getElementById("min-buyin");
-    const tDef = document.getElementById("default-buyin");
-    const tMax = document.getElementById("max-buyin");
-    const tSB  = document.getElementById("sb");
-    const tBB  = document.getElementById("bb");
-    const tBtn = document.getElementById("create-table");
-    const tStatus = document.getElementById("table-status");
-
     tBtn?.addEventListener("click", async () => {
+      if (!isAuthed()) {
+        tStatus.textContent = "Auth not ready";
+        setTimeout(() => (tStatus.textContent = ""), 2000);
+        return;
+      }
       const name = (tName.value || "").trim();
       const minC = parseDollarsToCents(tMin.value);
       const defC = parseDollarsToCents(tDef.value);
@@ -219,31 +228,33 @@
           buyIn: { minCents: minC, maxCents: maxC, defaultCents: defC },
         });
 
-        try {
-          const seatsCol = collection(tableRef, "seats");
-          const seatWrites = [];
-          for (let i = 0; i < maxSeats; i++) {
-            seatWrites.push(setDoc(doc(seatsCol, String(i)), {
-              seatIndex: i,
-              occupiedBy: null,
-              displayName: null,
-              sittingOut: false,
-              stackCents: null,
-              updatedAt: serverTimestamp(),
-            }));
+        (async () => {
+          try {
+            const seatsCol = collection(tableRef, "seats");
+            const seatWrites = [];
+            for (let i = 0; i < maxSeats; i++) {
+              seatWrites.push(setDoc(doc(seatsCol, String(i)), {
+                seatIndex: i,
+                occupiedBy: null,
+                displayName: null,
+                sittingOut: false,
+                stackCents: null,
+                updatedAt: serverTimestamp(),
+              }));
+            }
+            await Promise.all(seatWrites);
+            console.log('admin.seats.seed.ok', { count: seatWrites.length });
+          } catch (err) {
+            console.error('admin.seats.seed.fail', { code: err?.code, message: err?.message });
           }
-          await Promise.all(seatWrites);
-          console.log('admin.seats.seed.ok', { count: seatWrites.length });
-        } catch (err) {
-          console.error('admin.seats.seed.fail', err);
-        }
+        })();
 
         console.log('admin.table.create.ok', { id: tableRef.id });
         tStatus.textContent = `Table created: ${tableRef.id}`;
         tName.value = "";
       } catch (e) {
-        console.error('admin.table.create.fail', { code: e?.code });
-        tStatus.textContent = "Error: " + (e?.code || e?.message || e);
+        console.error('admin.table.create.fail', { code: e?.code, message: e?.message });
+        tStatus.textContent = `Error: ${e?.code || ''} ${e?.message || e}`;
       } finally {
         tBtn.disabled = false;
       }

--- a/public/auth.js
+++ b/public/auth.js
@@ -1,0 +1,22 @@
+import { app } from "/firebase-init.js";
+import { getAuth, onAuthStateChanged, signInAnonymously } from "https://www.gstatic.com/firebasejs/10.12.5/firebase-auth.js";
+
+export const auth = getAuth(app);
+let currentUser = auth.currentUser;
+let ready = false;
+let readyResolve;
+const readyPromise = new Promise((res) => { readyResolve = res; });
+
+onAuthStateChanged(auth, (u) => {
+  if (u) {
+    currentUser = u;
+    ready = true;
+    readyResolve(u);
+    console.log(`auth.anon.ready: uid=${u.uid}`);
+  } else {
+    signInAnonymously(auth).catch(console.error);
+  }
+});
+
+export const awaitAuthReady = () => (ready ? Promise.resolve(currentUser) : readyPromise);
+export const isAuthed = () => !!currentUser;

--- a/public/lobby.html
+++ b/public/lobby.html
@@ -32,13 +32,7 @@
       collection, query, orderBy, where, onSnapshot, doc, collection as subcol,
       runTransaction, serverTimestamp, increment, getDoc, updateDoc
     } from "https://www.gstatic.com/firebasejs/10.12.5/firebase-firestore.js";
-    import { getAuth, onAuthStateChanged, signInAnonymously } from "https://www.gstatic.com/firebasejs/10.12.5/firebase-auth.js";
-
-    const auth = getAuth(app);
-    onAuthStateChanged(auth, (u) => {
-      if (u) console.log(`auth.anon.ready: uid=${u.uid}`);
-      else signInAnonymously(auth).catch(console.error);
-    });
+    import { awaitAuthReady } from "/auth.js";
 
     renderCurrentPlayerControls("you");
     const debugChip = document.getElementById('debug-chip');
@@ -236,6 +230,7 @@
     });
 
     async function joinTable(tableId, cp, amountCents) {
+      await awaitAuthReady();
       let seatIndex = -1;
       try {
         await runTransaction(db, async (tx) => {
@@ -346,6 +341,7 @@
         if (!cp) { alert("Select a Current Player first."); return; }
         const tableId = leaveBtn.dataset.tableId;
 
+        await awaitAuthReady();
         const ok = confirm("Leave this table and return remaining chips to your wallet?");
         if (!ok) return;
 

--- a/public/table.html
+++ b/public/table.html
@@ -29,13 +29,7 @@
     import {
       doc, onSnapshot, collection, query, orderBy, addDoc, serverTimestamp
     } from "https://www.gstatic.com/firebasejs/10.12.5/firebase-firestore.js";
-    import { getAuth, onAuthStateChanged, signInAnonymously } from "https://www.gstatic.com/firebasejs/10.12.5/firebase-auth.js";
-
-    const auth = getAuth(app);
-    onAuthStateChanged(auth, (u) => {
-      if (u) console.log(`auth.anon.ready: uid=${u.uid}`);
-      else signInAnonymously(auth).catch(console.error);
-    });
+    import { awaitAuthReady } from "/auth.js";
 
     renderCurrentPlayerControls("you");
     const debugChip = document.getElementById('debug-chip');
@@ -229,6 +223,7 @@
           intentPending = true;
           disable(true);
           try {
+            await awaitAuthReady();
             await addDoc(intentsCol, { ...data, createdAt: serverTimestamp() });
           } catch (e) {
             console.error(e);


### PR DESCRIPTION
## Summary
- add awaitAuthReady() helper and disable create/add buttons until auth ready
- guard Create Table click when unauthenticated and show short toast
- log and surface Firestore addDoc errors with code and message
- create table with canonical payload and seed seats asynchronously
- await anonymous auth in Lobby/Table before seat and intent writes

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68c5f5140374832ebe827cd44f70c277