### PR TITLE
tooling: add in-app Debug Panel (+auth/fs instrumentation) with copyable report

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -88,16 +88,20 @@
       </table>
     </div>
   </div>
-
+  <script src="/jamlog.js"></script>
   <script type="module" src="/firebase-init.js"></script>
   <script type="module">
     import { app } from "/firebase-init.js";
-    import { db, dollars, parseDollarsToCents, renderCurrentPlayerControls } from "/common.js";
+    import { db, dollars, parseDollarsToCents, renderCurrentPlayerControls, isDebug } from "/common.js";
     import {
       collection, addDoc, serverTimestamp, query, orderBy, onSnapshot, where,
       doc, updateDoc, deleteDoc, setDoc
     } from "https://www.gstatic.com/firebasejs/10.12.5/firebase-firestore.js";
     import { awaitAuthReady, isAuthed } from "/auth.js";
+
+    if (window.jamlog && isDebug()) {
+      window.jamlog.init({ projectId: app.options.projectId, build: window.__BUILD_SHA__ || 'dev', page: 'ADMIN' });
+    }
 
     renderCurrentPlayerControls("you");
 
@@ -210,14 +214,17 @@
       const err = (m) => (tStatus.textContent = m);
 
       if (!name) return err("Enter a table name.");
-      if ([minC, defC, maxC, sbC, bbC].some(v => v === null)) return err("Enter valid numbers.");
+      const numericOk = ![minC, defC, maxC, sbC, bbC].some(v => v === null);
+      if (!numericOk) return err("Enter valid numbers.");
       if (minC > maxC) return err("Min buy-in > max.");
       if (defC < minC || defC > maxC) return err("Default must be between min and max.");
       if (sbC <= 0 || bbC <= 0) return err("Blinds must be > 0.");
 
+      if (window.jamlog) window.jamlog.push('admin.create.start', { numericOk, keys: ['name','active','createdAt','maxSeats','activeSeatCount','gameType','blinds','buyIn'] });
+
       tStatus.textContent = "Creating…"; tBtn.disabled = true;
       try {
-        const tableRef = await addDoc(tablesCol, {
+        const payload = {
           name,
           active: true,
           createdAt: serverTimestamp(),
@@ -226,7 +233,16 @@
           gameType: 'holdem',
           blinds: { sbCents: sbC, bbCents: bbC },
           buyIn: { minCents: minC, maxCents: maxC, defaultCents: defC },
-        });
+        };
+        if (window.jamlog) {
+          const shape = {};
+          Object.keys(payload).forEach(k => {
+            const v = payload[k];
+            shape[k] = typeof v === 'object' ? 'object' : typeof v;
+          });
+          window.jamlog.push('admin.create.payload', shape);
+        }
+        const tableRef = await addDoc(tablesCol, payload);
 
         (async () => {
           try {
@@ -243,17 +259,17 @@
               }));
             }
             await Promise.all(seatWrites);
-            console.log('admin.seats.seed.ok', { count: seatWrites.length });
+            if (window.jamlog) window.jamlog.push('admin.seats.seed.ok', { count: seatWrites.length });
           } catch (err) {
-            console.error('admin.seats.seed.fail', { code: err?.code, message: err?.message });
+            if (window.jamlog) window.jamlog.push('admin.seats.seed.fail', { code: err?.code, message: err?.message });
           }
         })();
 
-        console.log('admin.table.create.ok', { id: tableRef.id });
+        if (window.jamlog) window.jamlog.push('admin.create.ok', { tableId: tableRef.id });
         tStatus.textContent = `Table created: ${tableRef.id}`;
         tName.value = "";
       } catch (e) {
-        console.error('admin.table.create.fail', { code: e?.code, message: e?.message });
+        if (window.jamlog) window.jamlog.push('admin.create.fail', { code: e?.code, message: e?.message });
         tStatus.textContent = `Error: ${e?.code || ''} ${e?.message || e}`;
       } finally {
         tBtn.disabled = false;

--- a/public/index.html
+++ b/public/index.html
@@ -20,6 +20,14 @@
       <p id="fb-status" class="small"></p>
     </div>
   </div>
+  <script src="/jamlog.js"></script>
   <script type="module" src="/firebase-init.js"></script>
+  <script type="module">
+    import { app } from "/firebase-init.js";
+    import { isDebug } from "/common.js";
+    if (window.jamlog && isDebug()) {
+      window.jamlog.init({ projectId: app.options.projectId, build: window.__BUILD_SHA__ || 'dev', page: 'GLOBAL' });
+    }
+  </script>
 </body>
 </html>

--- a/public/jamlog.js
+++ b/public/jamlog.js
@@ -1,0 +1,181 @@
+(function(){
+  const maxEvents = 300;
+  const buffer = [];
+  const listeners = [];
+  const meta = { projectId: '', build: 'dev', page: 'GLOBAL', uid: null, tableId: null, ua: navigator.userAgent, url: location.href };
+  let active = false;
+
+  function isDebug(){
+    const params = new URLSearchParams(location.search);
+    return params.get('debug') === '1' || localStorage.getItem('debug') === '1';
+  }
+
+  function sanitizeCtx(ctx){
+    if (!ctx || typeof ctx !== 'object') return ctx;
+    const out = {};
+    for (const k in ctx){
+      const v = ctx[k];
+      if (v === null || v === undefined) continue;
+      const t = Array.isArray(v) ? 'array' : typeof v;
+      out[k] = t === 'object' ? 'object' : t;
+    }
+    return out;
+  }
+
+  function push(type, ctx){
+    if (!active) return;
+    const evt = { ts: new Date().toISOString(), page: meta.page || 'GLOBAL', type, uid: meta.uid, tableId: meta.tableId };
+    if (ctx) evt.ctx = ctx;
+    buffer.push(evt);
+    if (buffer.length > maxEvents) buffer.shift();
+    listeners.forEach(fn => fn(evt));
+  }
+
+  function init(opts){
+    if (active || !isDebug()) return;
+    active = true;
+    meta.projectId = opts.projectId || '';
+    meta.build = opts.build || 'dev';
+    meta.page = opts.page || 'GLOBAL';
+    if (opts.uid) meta.uid = opts.uid;
+    createButton();
+    push('app.start', { location: meta.url, ua: meta.ua });
+    updateHeader();
+  }
+
+  function setUid(uid){ meta.uid = uid; updateHeader(); }
+  function setTableId(tid){ meta.tableId = tid; }
+  function getEvents(){ return buffer.slice(); }
+  function clear(){ buffer.length = 0; if (logBody) logBody.innerHTML = ''; }
+
+  function exportJSON(){
+    return { meta: { ...meta, timestamp: new Date().toISOString() }, events: getEvents() };
+  }
+
+  function exportMarkdown(){
+    const data = exportJSON();
+    const lines = [
+      '# JamPoker Debug Report',
+      `- projectId: ${data.meta.projectId}`,
+      `- build: ${data.meta.build}`,
+      `- page: ${data.meta.page}`,
+      `- url: ${data.meta.url}`,
+      `- uid: ${data.meta.uid || 'none'}`,
+      `- userAgent: ${data.meta.ua}`,
+      `- timestamp: ${data.meta.timestamp}`,
+      '',
+      '## Recent Signals (last 30)'
+    ];
+    data.events.slice(-30).forEach(e => {
+      const snippet = e.ctx && (e.ctx.code || e.ctx.message) ? ` ${[e.ctx.code, e.ctx.message].filter(Boolean).join(' ')}` : '';
+      lines.push(`${e.ts} · ${e.type}${snippet}`);
+    });
+    lines.push('', '## Full Log (last 300)', '```json', JSON.stringify(data.events, null, 2), '```', '');
+    return lines.join('\n');
+  }
+
+  function onEvent(fn){ listeners.push(fn); }
+
+  // ---- UI ----
+  let button, panel, logBody, headerEl;
+  function createButton(){
+    button = document.createElement('div');
+    button.textContent = '🐞 Debug';
+    button.style.position = 'fixed';
+    button.style.bottom = '10px';
+    button.style.right = '10px';
+    button.style.background = '#0ea5e9';
+    button.style.color = 'white';
+    button.style.padding = '6px 10px';
+    button.style.borderRadius = '8px';
+    button.style.fontSize = '14px';
+    button.style.cursor = 'pointer';
+    button.style.zIndex = '9999';
+    button.addEventListener('click', openPanel);
+    document.body.appendChild(button);
+  }
+
+  function openPanel(){
+    if (panel) { panel.style.display = 'block'; return; }
+    panel = document.createElement('div');
+    panel.style.position = 'fixed';
+    panel.style.bottom = '0';
+    panel.style.right = '0';
+    panel.style.width = '360px';
+    panel.style.maxHeight = '70%';
+    panel.style.background = '#1f2937';
+    panel.style.color = '#f1f5f9';
+    panel.style.border = '1px solid #334155';
+    panel.style.borderRadius = '8px 0 0 0';
+    panel.style.display = 'flex';
+    panel.style.flexDirection = 'column';
+    panel.style.zIndex = '9999';
+
+    const header = document.createElement('div');
+    header.style.padding = '8px';
+    header.style.borderBottom = '1px solid #334155';
+    header.style.display = 'flex';
+    header.style.flexDirection = 'column';
+    headerEl = document.createElement('div');
+    headerEl.style.fontSize = '12px';
+    headerEl.style.marginBottom = '6px';
+    header.appendChild(headerEl);
+
+    const btnRow = document.createElement('div');
+    btnRow.style.display = 'flex';
+    btnRow.style.gap = '6px';
+    const copyBtn = document.createElement('button');
+    copyBtn.textContent = 'Copy Report';
+    copyBtn.addEventListener('click', () => {
+      navigator.clipboard.writeText(exportMarkdown());
+    });
+    const dlBtn = document.createElement('button');
+    dlBtn.textContent = 'Download JSON';
+    dlBtn.addEventListener('click', () => {
+      const blob = new Blob([JSON.stringify(exportJSON(), null, 2)], { type: 'application/json' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = 'jamlog.json';
+      a.click();
+      setTimeout(() => URL.revokeObjectURL(url), 1000);
+    });
+    const clrBtn = document.createElement('button');
+    clrBtn.textContent = 'Clear';
+    clrBtn.addEventListener('click', () => clear());
+    btnRow.appendChild(copyBtn);
+    btnRow.appendChild(dlBtn);
+    btnRow.appendChild(clrBtn);
+    header.appendChild(btnRow);
+
+    logBody = document.createElement('div');
+    logBody.style.flex = '1';
+    logBody.style.overflowY = 'auto';
+    logBody.style.fontFamily = 'monospace';
+    logBody.style.fontSize = '11px';
+    logBody.style.padding = '8px';
+
+    panel.appendChild(header);
+    panel.appendChild(logBody);
+    document.body.appendChild(panel);
+    getEvents().forEach(appendRow);
+  }
+
+  function appendRow(evt){
+    if (!logBody) return;
+    const line = document.createElement('div');
+    const ctxStr = evt.ctx ? ' ' + JSON.stringify(evt.ctx) : '';
+    line.textContent = `${evt.ts} ${evt.type}${ctxStr}`;
+    logBody.appendChild(line);
+    logBody.scrollTop = logBody.scrollHeight;
+  }
+
+  function updateHeader(){
+    if (!headerEl) return;
+    headerEl.textContent = `projectId=${meta.projectId} build=${meta.build} page=${meta.page} uid=${meta.uid || 'none'}`;
+  }
+
+  onEvent(appendRow);
+
+  window.jamlog = { init, push, exportJSON, exportMarkdown, clear, setUid, setTableId, onEvent, meta };
+})();

--- a/public/lobby.html
+++ b/public/lobby.html
@@ -23,7 +23,7 @@
       <div id="tables" class="small">Loading tables…</div>
     </div>
   </div>
-
+  <script src="/jamlog.js"></script>
   <script type="module" src="/firebase-init.js"></script>
   <script type="module">
     import { app } from "/firebase-init.js";
@@ -33,6 +33,9 @@
       runTransaction, serverTimestamp, increment, getDoc, updateDoc
     } from "https://www.gstatic.com/firebasejs/10.12.5/firebase-firestore.js";
     import { awaitAuthReady } from "/auth.js";
+    if (window.jamlog && isDebug()) {
+      window.jamlog.init({ projectId: app.options.projectId, build: window.__BUILD_SHA__ || 'dev', page: 'LOBBY' });
+    }
 
     renderCurrentPlayerControls("you");
     const debugChip = document.getElementById('debug-chip');
@@ -146,9 +149,9 @@
       const q = useFallback
         ? query(tablesCol, where('active', '==', true))
         : query(tablesCol, where('active', '==', true), orderBy('createdAt', 'desc'));
-      debugLog(useFallback ? 'lobby.query.started.fallback' : 'lobby.query.started');
+      if (window.jamlog) window.jamlog.push('lobby.query.start');
       onSnapshot(q, (snap) => {
-        debugLog('lobby.tablesSnapshot', snap.size);
+        if (window.jamlog) window.jamlog.push('lobby.query.ok', { count: snap.size });
         blocks = [];
         seatUnsubs.forEach(u => u());
         seatUnsubs.clear();
@@ -156,8 +159,6 @@
         handUnsubs.clear();
 
         const docs = [...snap.docs].sort((a,b) => (b.data()?.createdAt?.toMillis?.() || 0) - (a.data()?.createdAt?.toMillis?.() || 0));
-        if (snap.empty) debugLog('lobby.query.empty (0 docs)');
-        else debugLog('lobby.query.ok', { count: snap.size });
 
         docs.forEach(docSnap => {
           const id = docSnap.id;
@@ -203,11 +204,14 @@
         renderAll();
       }, (err) => {
         if (err.code === 'failed-precondition' && !useFallback) {
-          debugLog('lobby.query.fallback.index_missing');
+          if (window.jamlog) window.jamlog.push('lobby.query.fallback.index_missing');
           startTablesListener(true);
         } else {
-          if (err.code === 'permission-denied') debugLog('lobby.query.permissionDenied');
-          else debugLog('lobby.query.error', err);
+          if (err.code === 'permission-denied') {
+            if (window.jamlog) window.jamlog.push('lobby.query.permission_denied');
+          } else {
+            if (window.jamlog) window.jamlog.push('lobby.query.error', { code: err?.code, message: err?.message });
+          }
           listEl.textContent = err.code === 'permission-denied' ? 'Cannot load tables: permission denied.' : 'Error loading tables.';
         }
       });
@@ -231,6 +235,7 @@
 
     async function joinTable(tableId, cp, amountCents) {
       await awaitAuthReady();
+      if (window.jamlog) window.jamlog.push('seat.tx.claim.start', { tableId });
       let seatIndex = -1;
       try {
         await runTransaction(db, async (tx) => {
@@ -289,9 +294,9 @@
           });
           tx.update(tableRef, { activeSeatCount: increment(1) });
         });
-        debugLog('seat.tx.claim.ok', { seatIndex, uid: cp.id });
+        if (window.jamlog) window.jamlog.push('seat.tx.claim.ok', { seatIndex });
       } catch (err) {
-        debugLog('seat.tx.claim.fail', { code: err?.code });
+        if (window.jamlog) window.jamlog.push('seat.tx.claim.fail', { code: err?.code, message: err?.message });
         const msg = err?.code === 'permission-denied'
           ? "You're not signed in. Try again in 2s."
           : "Seat taken—try another.";
@@ -345,6 +350,7 @@
         const ok = confirm("Leave this table and return remaining chips to your wallet?");
         if (!ok) return;
 
+        if (window.jamlog) window.jamlog.push('seat.tx.leave.start', { tableId });
         try {
           await runTransaction(db, async (tx) => {
             const playerRef = doc(db, "players", cp.id);
@@ -384,9 +390,9 @@
             tx.update(tableRef, { activeSeatCount: increment(-1) });
           });
           alert("You left the table. Chips returned to wallet.");
-          debugLog('seat.tx.leave.ok');
+          if (window.jamlog) window.jamlog.push('seat.tx.leave.ok');
         } catch (err) {
-          debugLog('seat.tx.leave.fail', { code: err?.code });
+          if (window.jamlog) window.jamlog.push('seat.tx.leave.fail', { code: err?.code, message: err?.message });
           const msg = err?.code === 'permission-denied'
             ? "You're not signed in. Try again in 2s."
             : "Error leaving seat.";

--- a/public/table.html
+++ b/public/table.html
@@ -21,7 +21,7 @@
   </div>
   <div id="player-board" class="card" style="display:none;position:fixed;left:50%;bottom:0;transform:translateX(-50%);min-width:260px;"></div>
   <div id="debug-box" class="dbg" style="display:none;font-family:monospace;white-space:pre;font-size:11px;margin-top:12px;"></div>
-
+  <script src="/jamlog.js"></script>
   <script type="module" src="/firebase-init.js"></script>
   <script type="module">
     import { app } from "/firebase-init.js";
@@ -31,6 +31,10 @@
     } from "https://www.gstatic.com/firebasejs/10.12.5/firebase-firestore.js";
     import { awaitAuthReady } from "/auth.js";
 
+    if (window.jamlog && isDebug()) {
+      window.jamlog.init({ projectId: app.options.projectId, build: window.__BUILD_SHA__ || 'dev', page: 'TABLE' });
+    }
+
     renderCurrentPlayerControls("you");
     const debugChip = document.getElementById('debug-chip');
     debugChip.textContent = isDebug() ? 'Debug: ON' : 'Debug: OFF';
@@ -38,6 +42,7 @@
 
     const params = new URLSearchParams(window.location.search);
     const tableId = params.get('id');
+    if (window.jamlog) window.jamlog.setTableId(tableId || null);
     const errorEl = document.getElementById('error');
     const infoEl = document.getElementById('table-info');
     const handEl = document.getElementById('current-hand');
@@ -118,6 +123,9 @@
       const rangeStr = `${dollars(minB)}–${dollars(maxB)} (default ${dollars(defB)})`;
       const derivedSeatCount = seatData.filter(s => s.occupiedBy).length;
       const activeSeatCount = t.activeSeatCount ?? 0;
+      if (window.jamlog && derivedSeatCount !== activeSeatCount) {
+        window.jamlog.push('seatcount.status', { activeSeatCount, derived: derivedSeatCount });
+      }
       infoEl.innerHTML = `
         <h1>${t.name || '(no name)'}</h1>
         <div class="small">Blinds: ${blindStr}</div>


### PR DESCRIPTION
## Summary
- add lightweight `jamlog` logger with ring buffer, copyable Markdown report and JSON export
- wire admin, lobby, and table pages to stream auth and Firestore events into the Debug Panel
- surface "🐞 Debug" toggle when `?debug=1` for quick diagnostics

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c5f7a88298832e86e20921468ce99a