### PR TITLE
brief-11c.hotfix-9+: fix admin auth logging and document API key restrictions

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -194,12 +194,12 @@
     __adminDbg.push('app.start', { url: location.href });
 
     const auth = getAuth(app);
-    __adminDbg.push('auth.signInAnonymously.start');
     onAuthStateChanged(auth, (u) => {
       if (u) {
         __adminDbg.setUid(u.uid);
         __adminDbg.push('auth.ready', { uid: u.uid });
       } else {
+        __adminDbg.push('auth.signInAnonymously.start');
         signInAnonymously(auth)
           .then(() => __adminDbg.push('auth.signInAnonymously.ok'))
           .catch((e) => __adminDbg.push('auth.signInAnonymously.fail', { code: e?.code, message: e?.message }));

--- a/public/firebase-init.js
+++ b/public/firebase-init.js
@@ -2,6 +2,7 @@
 import { initializeApp } from "https://www.gstatic.com/firebasejs/10.12.5/firebase-app.js";
 
 const firebaseConfig = {
+  // API key is restricted via HTTP referrers and Identity Toolkit API only
   apiKey: "AIzaSyA2xi-TpIZYXJP8WIeLuSojgNHmUJMe0vc",
   authDomain: "jam-poker.firebaseapp.com",
   projectId: "jam-poker",


### PR DESCRIPTION
## Summary
- log anonymous auth start only when needed so debug shows full auth flow
- note API key is locked to trusted referrers and Identity Toolkit API

## Testing
- `npm test` *(fails: no package.json)*
- `cd functions && npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c5feac006c832e8f2f14cb67c1b31e