### PR TITLE
11e: seat subscription + safe backfill + derived/active guard

### DIFF
--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -17,6 +17,7 @@
 - **brief-11c.hotfix-2** complete — lobby visibility, join flow, player board
 - **brief-11c.hotfix-4** complete — anon auth + join permissions
 - **brief-11c.hotfix-5** complete — admin create table + seat seeding + dev rules
+- **brief-11e** complete — seat subscription + safe backfill + derived/active guard
 
 ## Open Issues / Next Steps
 - Verify **Board UI** renders in /table.html after closing preflop.

--- a/public/admin.html
+++ b/public/admin.html
@@ -73,6 +73,7 @@
       <div style="display:flex;justify-content:space-between;align-items:center;">
         <h2 style="margin-top:0;">Tables</h2>
         <div style="display:flex;gap:8px;align-items:center;">
+          <button id="backfill-seats" style="padding:4px 8px;border-radius:8px;border:1px solid #334155;background:#0ea5e9;color:white;font-weight:700;cursor:pointer">Backfill seats</button>
           <button id="delete-all-tables" style="padding:4px 8px;border-radius:8px;border:1px solid #7f1d1d;background:#ef4444;color:white;font-weight:700;cursor:pointer">Delete ALL tables</button>
         </div>
       </div>
@@ -183,10 +184,10 @@
   <script type="module">
     import { app } from "/firebase-init.js";
     import { db, dollars, parseDollarsToCents, renderCurrentPlayerControls, isDebug } from "/common.js";
-    import {
-      collection, addDoc, serverTimestamp, query, orderBy, onSnapshot, where,
-      doc, updateDoc, deleteDoc, setDoc, writeBatch
-    } from "https://www.gstatic.com/firebasejs/10.12.5/firebase-firestore.js";
+      import {
+        collection, addDoc, serverTimestamp, query, orderBy, onSnapshot, where,
+        doc, updateDoc, deleteDoc, setDoc, writeBatch, getDocs
+      } from "https://www.gstatic.com/firebasejs/10.12.5/firebase-firestore.js";
     import { getAuth, onAuthStateChanged, signInAnonymously } from "https://www.gstatic.com/firebasejs/10.12.5/firebase-auth.js";
     import { awaitAuthReady, isAuthed } from "/auth.js";
 
@@ -414,15 +415,51 @@
       }
     });
 
-    const tablesBody = document.getElementById("tables-body");
-    const deleteAllBtn = document.getElementById("delete-all-tables");
+      const tablesBody = document.getElementById("tables-body");
+      const deleteAllBtn = document.getElementById("delete-all-tables");
+      const backfillBtn = document.getElementById("backfill-seats");
 
-    deleteAllBtn?.addEventListener("click", async () => {
-      const conf = prompt("Type DELETE ALL") === "DELETE ALL";
-      if (!conf) return;
-      try {
-        const res = await fetch("/adminDeleteAllTables", { method: "POST" });
-        const data = await res.json();
+      backfillBtn?.addEventListener("click", async () => {
+        try {
+          if (window.jamlog) window.jamlog.push('admin.backfill.start');
+          const snap = await getDocs(query(tablesCol, where("active", "==", true)));
+          let tbls = 0;
+          let seats = 0;
+          for (const tdoc of snap.docs) {
+            const max = tdoc.data()?.maxSeats || 0;
+            const seatsSnap = await getDocs(collection(db, 'tables', tdoc.id, 'seats'));
+            if (seatsSnap.size === 0 && max > 0) {
+              const batch = writeBatch(db);
+              for (let i = 0; i < max; i++) {
+                const sref = doc(db, 'tables', tdoc.id, 'seats', String(i));
+                batch.set(sref, {
+                  seatIndex: i,
+                  occupiedBy: null,
+                  displayName: null,
+                  sittingOut: false,
+                  stackCents: null,
+                  updatedAt: serverTimestamp(),
+                }, { merge: false });
+              }
+              await batch.commit();
+              tbls++;
+              seats += max;
+            }
+          }
+          if (window.jamlog) window.jamlog.push('admin.backfill.ok', { tables: tbls, seats });
+          alert(`Backfilled seats on ${tbls} tables.`);
+        } catch (err) {
+          if (window.jamlog) window.jamlog.push('admin.backfill.fail', { code: err?.code });
+          alert('Error backfilling seats.');
+        }
+      });
+
+      deleteAllBtn?.addEventListener("click", async () => {
+        const conf = prompt("Type DELETE ALL") === "DELETE ALL";
+        if (!conf) return;
+        try {
+          const res = await fetch("/adminDeleteAllTables", { method: "POST" });
+          const data = await res.json();
         if (!res.ok || !data.ok) throw new Error(data.error || "Error");
         alert("All tables deleted.");
       } catch (err) {

--- a/public/table.html
+++ b/public/table.html
@@ -27,7 +27,7 @@
     import { app } from "/firebase-init.js";
     import { db, dollars, renderCurrentPlayerControls, isDebug, setDebug, getCurrentPlayer, formatCard, stageLabel, showSeatsDebug, debugLog } from "/common.js";
     import {
-      doc, onSnapshot, collection, query, orderBy, addDoc, serverTimestamp
+      doc, onSnapshot, collection, query, orderBy, addDoc, serverTimestamp, writeBatch
     } from "https://www.gstatic.com/firebasejs/10.12.5/firebase-firestore.js";
     import { awaitAuthReady } from "/auth.js";
 
@@ -49,11 +49,19 @@
     const seatsEl = document.getElementById('seats');
     const boardEl = document.getElementById('player-board');
     const debugBox = document.getElementById('debug-box');
+    const seedBanner = document.createElement('div');
+    seedBanner.className = 'small';
+    seedBanner.textContent = 'Seeding seats…';
+    seedBanner.style.display = 'none';
+    seatsEl.before(seedBanner);
 
     let tableData = null;
     let handData = null;
     let seatData = [];
     let unsubHand = null;
+    let backfillAttempted = false;
+    let seatCountTimer = null;
+    let seatCountDesync = false;
 
     if (!tableId) {
       errorEl.style.display = 'block';
@@ -90,26 +98,94 @@
           renderHand();
           updateDebug();
         }
-        renderPlayerBoard();
-        updateDebug();
-      });
+          renderPlayerBoard();
+          updateDebug();
+          checkSeatCount();
+        });
 
-      const seatsRef = collection(db, 'tables', tableId, 'seats');
-      onSnapshot(query(seatsRef, orderBy('seatIndex', 'asc')), (snap) => {
-        debugLog('table.seatsSnapshot', snap.size);
-        seatData = snap.docs.map((d) => ({ id: d.id, ...d.data() }));
-        showSeatsDebug(tableId, snap.docs);
-        renderSeats();
-        renderHand();
-        renderTableInfo();
-        renderPlayerBoard();
-        updateDebug();
-      });
-    }
+        const seatsRef = collection(db, 'tables', tableId, 'seats');
+        if (window.jamlog) window.jamlog.push('table.seats.sub.started');
+        const qSeats = query(seatsRef, orderBy('seatIndex', 'asc'));
+        onSnapshot(qSeats, (snap) => {
+          debugLog('table.seatsSnapshot', snap.size);
+          if (window.jamlog) window.jamlog.push('table.seats.sub.ok', { count: snap.size });
+          seatData = snap.docs.map((d) => ({ id: d.id, ...d.data() }));
+          showSeatsDebug(tableId, snap.docs);
+          renderSeats();
+          renderHand();
+          renderTableInfo();
+          renderPlayerBoard();
+          updateDebug();
+          checkSeatCount();
+        }, (err) => {
+          if (window.jamlog) window.jamlog.push('table.seats.sub.error', { code: err?.code });
+        });
+        setTimeout(checkBackfill, 1500);
+      }
 
     document.addEventListener('change', (e) => {
       if (e.target.id === 'cp-select') renderPlayerBoard();
     });
+
+    function checkBackfill() {
+      if (backfillAttempted) return;
+      if (!tableData) { setTimeout(checkBackfill, 500); return; }
+      if (seatData.length === 0 && (tableData.maxSeats || 0) > 0) {
+        backfillSeats();
+      }
+    }
+
+    async function backfillSeats() {
+      backfillAttempted = true;
+      if (isDebug()) seedBanner.style.display = 'block';
+      try {
+        const batch = writeBatch(db);
+        const max = tableData.maxSeats || 0;
+        for (let i = 0; i < max; i++) {
+          const sref = doc(db, 'tables', tableId, 'seats', String(i));
+          batch.set(sref, {
+            seatIndex: i,
+            occupiedBy: null,
+            displayName: null,
+            sittingOut: false,
+            stackCents: null,
+            updatedAt: serverTimestamp(),
+          }, { merge: false });
+        }
+        await batch.commit();
+        if (window.jamlog) window.jamlog.push('table.seats.backfill.ok', { count: max });
+      } catch (e) {
+        if (window.jamlog) window.jamlog.push('table.seats.backfill.fail', { code: e?.code });
+      } finally {
+        if (isDebug()) seedBanner.style.display = 'none';
+      }
+    }
+
+    function checkSeatCount() {
+      if (!tableData) return;
+      const derived = seatData.filter(s => s.occupiedBy).length;
+      const active = tableData.activeSeatCount ?? 0;
+      if (derived !== active) {
+        if (!seatCountTimer) {
+          seatCountTimer = setTimeout(() => {
+            seatCountTimer = null;
+            const d = seatData.filter(s => s.occupiedBy).length;
+            const a = tableData.activeSeatCount ?? 0;
+            if (d !== a) {
+              seatCountDesync = true;
+              if (window.jamlog) window.jamlog.push('seatcount.desync', { derived: d, activeSeatCount: a });
+              renderTableInfo();
+            }
+          }, 1000);
+        }
+      } else {
+        if (seatCountTimer) { clearTimeout(seatCountTimer); seatCountTimer = null; }
+        if (seatCountDesync) {
+          seatCountDesync = false;
+          renderTableInfo();
+        }
+      }
+    }
 
     function renderTableInfo() {
       if (!tableData) { infoEl.textContent = ''; return; }
@@ -123,14 +199,13 @@
       const rangeStr = `${dollars(minB)}–${dollars(maxB)} (default ${dollars(defB)})`;
       const derivedSeatCount = seatData.filter(s => s.occupiedBy).length;
       const activeSeatCount = t.activeSeatCount ?? 0;
-      if (window.jamlog && derivedSeatCount !== activeSeatCount) {
-        window.jamlog.push('seatcount.status', { activeSeatCount, derived: derivedSeatCount });
-      }
+      const desyncLine = seatCountDesync ? `<div class="small">Players seated: ${derivedSeatCount} (active: ${activeSeatCount})</div>` : '';
       infoEl.innerHTML = `
         <h1>${t.name || '(no name)'}</h1>
         <div class="small">Blinds: ${blindStr}</div>
         <div class="small">Buy-in: ${rangeStr}</div>
-        <div class="small">Seats: ${derivedSeatCount} (active: ${activeSeatCount}) / ${t.maxSeats || 0}</div>
+        <div class="small">Seats: ${derivedSeatCount} / ${t.maxSeats || 0}</div>
+        ${desyncLine}
       `;
     }
 


### PR DESCRIPTION
## Summary
- subscribe to table seat docs with logging
- backfill missing seat docs in batch and watch for desync
- admin utility for backfilling seats on active tables

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68c6079716d0832e98a7968d553a2b8d