### PR TITLE
12b: Start Hand → Dealer/SB/BB badges (no chips yet)

### DIFF
--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -21,6 +21,7 @@
 - **brief-11e** complete — seat subscription + safe backfill + derived/active guard
 - **brief-11f.hotfix** complete — seat txn allowed-keys only + stable seats subscription (+ backfill)
 - **brief-12a** complete — auto-stack on seat claim + stack display
+- **brief-12b** complete — Start Hand button with Dealer/SB/BB badges
 
 ## Open Issues / Next Steps
 - Verify **Board UI** renders in /table.html after closing preflop.

--- a/firestore.rules
+++ b/firestore.rules
@@ -56,6 +56,13 @@ service cloud.firestore {
       }
     }
 
+    match /tables/{tableId}/hand/{docId} {
+      allow read: if true;
+      allow create, update: if request.auth != null
+        && onlyAllowedKeys(['handNo','dealerSeat','sbSeat','bbSeat','toActSeat','updatedAt']);
+      allow delete: if false;
+    }
+
     // Hands are server-managed only.
     match /tables/{tableId}/hands/{handId} {
       allow read: if true;

--- a/public/admin.html
+++ b/public/admin.html
@@ -186,7 +186,7 @@
     import { db, dollars, parseDollarsToCents, renderCurrentPlayerControls, isDebug } from "/common.js";
       import {
         collection, addDoc, serverTimestamp, query, orderBy, onSnapshot, where,
-        doc, updateDoc, deleteDoc, setDoc, writeBatch, getDocs
+        doc, updateDoc, deleteDoc, setDoc, writeBatch, getDocs, getDoc
       } from "https://www.gstatic.com/firebasejs/10.12.5/firebase-firestore.js";
     import { getAuth, onAuthStateChanged, signInAnonymously } from "https://www.gstatic.com/firebasejs/10.12.5/firebase-auth.js";
     import { awaitAuthReady, isAuthed } from "/auth.js";
@@ -489,6 +489,7 @@
           <td style="padding:8px;border-bottom:1px solid #334155;">${seated}</td>
           <td style="padding:8px;border-bottom:1px solid #334155;text-align:right;">
             <a href="/table.html?id=${id}" style="padding:4px 8px;border-radius:8px;border:1px solid #334155;background:#0ea5e9;color:white;font-size:12px;text-decoration:none;">Open</a>
+            <button class="start-hand" style="padding:4px 8px;border-radius:8px;border:1px solid #334155;background:#3b82f6;color:white;font-size:12px;cursor:pointer;">Start Hand</button>
             <button class="archive-table" style="padding:4px 8px;border-radius:8px;border:1px solid #7f1d1d;background:#ef4444;color:white;font-size:12px;cursor:pointer;">Archive</button>
           </td>
         </tr>`;
@@ -545,22 +546,64 @@
       });
     }
 
+    async function startHand(tableId) {
+      if (window.jamlog) window.jamlog.push('hand.start.click');
+      const seatsCol = collection(doc(db, 'tables', tableId), 'seats');
+      try {
+        await awaitAuthReady();
+        const snap = await getDocs(query(seatsCol, orderBy('seatIndex', 'asc')));
+        const occupied = [];
+        snap.forEach((d) => {
+          const s = d.data();
+          if (s.occupiedBy) occupied.push(s.seatIndex);
+        });
+        const stateRef = doc(db, 'tables', tableId, 'hand', 'state');
+        const stateSnap = await getDoc(stateRef);
+        const currentState = stateSnap.exists() ? stateSnap.data() : null;
+        if (occupied.length < 2) {
+          const handNo = typeof currentState?.handNo === 'number' ? currentState.handNo : 0;
+          await setDoc(stateRef, { handNo, dealerSeat: null, sbSeat: null, bbSeat: null, toActSeat: null, updatedAt: serverTimestamp() }, { merge: true });
+          if (window.jamlog) window.jamlog.push('hand.start.fail', { code: 'not-enough-players', message: 'Need 2+ players' });
+          alert('Need 2+ players');
+          return;
+        }
+        const next = (arr, val) => arr[(arr.indexOf(val) + 1) % arr.length];
+        let dealer;
+        if (currentState && occupied.includes(currentState.dealerSeat)) dealer = next(occupied, currentState.dealerSeat);
+        else dealer = occupied[0];
+        const sb = next(occupied, dealer);
+        const bb = next(occupied, sb);
+        const toAct = next(occupied, bb);
+        const handNo = (typeof currentState?.handNo === 'number' ? currentState.handNo : 0) + 1;
+        await setDoc(stateRef, { handNo, dealerSeat: dealer, sbSeat: sb, bbSeat: bb, toActSeat: toAct, updatedAt: serverTimestamp() }, { merge: true });
+        if (window.jamlog) window.jamlog.push('hand.start.ok', { handNo, dealerSeat: dealer, sbSeat: sb, bbSeat: bb, toActSeat: toAct });
+      } catch (err) {
+        if (window.jamlog) window.jamlog.push('hand.start.fail', { code: err?.code, message: err?.message });
+        alert('Error starting hand.');
+      }
+    }
+
     startTablesListener();
 
     tablesBody?.addEventListener("click", async (e) => {
-      if (!e.target.classList.contains("archive-table")) return;
-      const row = e.target.closest("tr");
+      const target = e.target;
+      const row = target.closest("tr");
+      if (!row) return;
       const id = row.getAttribute("data-id");
-      const conf = confirm("Archive this table?");
-      if (!conf) return;
-      try {
-        await updateDoc(doc(db, "tables", id), {
-          active: false,
-          deletedAt: serverTimestamp(),
-        });
-        alert("Table archived.");
-      } catch (err) {
-        alert("Error: " + (err?.message || err));
+      if (target.classList.contains("archive-table")) {
+        const conf = confirm("Archive this table?");
+        if (!conf) return;
+        try {
+          await updateDoc(doc(db, "tables", id), {
+            active: false,
+            deletedAt: serverTimestamp(),
+          });
+          alert("Table archived.");
+        } catch (err) {
+          alert("Error: " + (err?.message || err));
+        }
+      } else if (target.classList.contains("start-hand")) {
+        await startHand(id);
       }
     });
 

--- a/public/table.css
+++ b/public/table.css
@@ -37,3 +37,19 @@ body.variant-v1 .community-card.enter {
   flex-direction: column;
   justify-content: center;
   align-items: center;
+}
+
+.seat .pos-badge {
+  position: absolute;
+  top: -4px;
+  right: -4px;
+  background: #0ea5e9;
+  color: #fff;
+  font-size: 10px;
+  padding: 2px 4px;
+  border-radius: 4px;
+}
+
+.seat .pos-badge.dealer { background: #6b7280; }
+.seat .pos-badge.sb { background: #3b82f6; }
+.seat .pos-badge.bb { background: #1d4ed8; }

--- a/public/table.html
+++ b/public/table.html
@@ -28,7 +28,7 @@
     import { app } from "/firebase-init.js";
     import { db, dollars, formatCents, renderCurrentPlayerControls, isDebug, setDebug, getCurrentPlayer, formatCard, stageLabel, showSeatsDebug, debugLog } from "/common.js";
     import {
-      doc, onSnapshot, collection, query, orderBy, addDoc, serverTimestamp,
+      doc, setDoc, onSnapshot, collection, query, orderBy, addDoc, serverTimestamp,
       writeBatch, runTransaction, increment, getDoc
     } from "https://www.gstatic.com/firebasejs/10.12.5/firebase-firestore.js";
     import { awaitAuthReady } from "/auth.js";
@@ -60,8 +60,10 @@
 
     let tableData = null;
     let handData = null;
+    let handState = null;
     let seatData = [];
     let unsubHand = null;
+    let unsubHandState = null;
     let backfillAttempted = false;
     let backfillTimer = null;
     let seatCountTimer = null;
@@ -72,6 +74,13 @@
       errorEl.innerHTML = '<h1>Table not found</h1><a href="/lobby.html">Back to Lobby</a>';
     } else {
       const tableRef = doc(db, 'tables', tableId);
+      const handStateRef = doc(db, 'tables', tableId, 'hand', 'state');
+      if (window.jamlog) window.jamlog.push('hand.state.sub.start');
+      unsubHandState = onSnapshot(handStateRef, (snap) => {
+        handState = snap.exists() ? snap.data() : null;
+        renderSeats();
+        if (window.jamlog) window.jamlog.push('hand.state.sub.ok', { handNo: handState?.handNo ?? null });
+      });
       onSnapshot(tableRef, (snap) => {
         debugLog('table.tableSnapshot', snap.exists());
         if (!snap.exists() || snap.data()?.active === false) {
@@ -212,13 +221,20 @@
       const derivedSeatCount = seatData.filter(s => s.occupiedBy).length;
       const activeSeatCount = t.activeSeatCount ?? 0;
       const desyncLine = seatCountDesync ? `<div class="small">Players seated: ${derivedSeatCount} (active: ${activeSeatCount})</div>` : '';
+      const current = getCurrentPlayer();
+      const showStart = (current && seatData.some(s => s.occupiedBy === current.id)) || isDebug();
+      const startBtnHtml = showStart ? `<div style="margin-top:8px;text-align:right;"><button id="btn-start-hand" class="small">Start Hand</button></div>` : '';
       infoEl.innerHTML = `
         <h1>${t.name || '(no name)'}</h1>
         <div class="small">Blinds: ${blindStr}</div>
         <div class="small">Buy-in: ${rangeStr}</div>
         <div class="small">Seats: ${derivedSeatCount} / ${t.maxSeats || 0}</div>
         ${desyncLine}
+        ${startBtnHtml}
       `;
+      if (showStart) {
+        document.getElementById('btn-start-hand')?.addEventListener('click', startHand);
+      }
     }
 
     function renderHand() {
@@ -286,6 +302,26 @@
         } else {
           seatEl.innerHTML = '<div class="small">Sit here</div>';
           seatEl.addEventListener('click', () => claimSeat(i));
+        }
+        if (handState) {
+          if (i === handState.dealerSeat) {
+            const b = document.createElement('div');
+            b.className = 'pos-badge dealer';
+            b.textContent = 'D';
+            seatEl.appendChild(b);
+          }
+          if (i === handState.sbSeat) {
+            const b = document.createElement('div');
+            b.className = 'pos-badge sb';
+            b.textContent = 'SB';
+            seatEl.appendChild(b);
+          }
+          if (i === handState.bbSeat) {
+            const b = document.createElement('div');
+            b.className = 'pos-badge bb';
+            b.textContent = 'BB';
+            seatEl.appendChild(b);
+          }
         }
         ring.appendChild(seatEl);
       }
@@ -381,6 +417,43 @@
           else window.jamlog.push('seat.tx.fail.seatWrite', { code: err?.code });
           window.jamlog.push('seat.tx.fail', { seatIndex, code: err?.code, message: err?.message });
         }
+      }
+    }
+
+    async function startHand() {
+      if (window.jamlog) window.jamlog.push('hand.start.click');
+      const occupied = seatData.filter(s => s.occupiedBy).map(s => s.seatIndex).sort((a,b) => a - b);
+      const stateRef = doc(db, 'tables', tableId, 'hand', 'state');
+      try {
+        await awaitAuthReady();
+        let currentState = handState;
+        if (!currentState) {
+          const snap = await getDoc(stateRef);
+          currentState = snap.exists() ? snap.data() : null;
+        }
+        if (occupied.length < 2) {
+          const handNo = typeof currentState?.handNo === 'number' ? currentState.handNo : 0;
+          await setDoc(stateRef, { handNo, dealerSeat: null, sbSeat: null, bbSeat: null, toActSeat: null, updatedAt: serverTimestamp() }, { merge: true });
+          if (window.jamlog) window.jamlog.push('hand.start.fail', { code: 'not-enough-players', message: 'Need 2+ players' });
+          alert('Need 2+ players');
+          return;
+        }
+        const next = (arr, val) => arr[(arr.indexOf(val) + 1) % arr.length];
+        let dealer;
+        if (currentState && occupied.includes(currentState.dealerSeat)) {
+          dealer = next(occupied, currentState.dealerSeat);
+        } else {
+          dealer = occupied[0];
+        }
+        const sb = next(occupied, dealer);
+        const bb = next(occupied, sb);
+        const toAct = next(occupied, bb);
+        const handNo = (typeof currentState?.handNo === 'number' ? currentState.handNo : 0) + 1;
+        await setDoc(stateRef, { handNo, dealerSeat: dealer, sbSeat: sb, bbSeat: bb, toActSeat: toAct, updatedAt: serverTimestamp() }, { merge: true });
+        if (window.jamlog) window.jamlog.push('hand.start.ok', { handNo, dealerSeat: dealer, sbSeat: sb, bbSeat: bb, toActSeat: toAct });
+      } catch (err) {
+        if (window.jamlog) window.jamlog.push('hand.start.fail', { code: err?.code, message: err?.message });
+        alert('Error starting hand.');
       }
     }
 


### PR DESCRIPTION
## Summary
- add hand state rules and start-hand computation on table and admin pages
- render dealer, small blind, and big blind badges on the table ring
- log hand start events and subscribe to hand state updates

## Testing
- `npm test` *(fails: Could not read package.json)*
- `cd functions && npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68c61455c4dc832ea705b77d5b25fc59