### PR TITLE
12b execute: Start Hand + Dealer/SB/BB badges (hand/state + rules)

### DIFF
--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -22,6 +22,7 @@
 - **brief-11f.hotfix** complete — seat txn allowed-keys only + stable seats subscription (+ backfill)
 - **brief-12a** complete — auto-stack on seat claim + stack display
 - **brief-12b** complete — Start Hand button with Dealer/SB/BB badges
+- **brief-12b.execute** done — Start Hand action + hand/state rules
 
 ## Open Issues / Next Steps
 - Verify **Board UI** renders in /table.html after closing preflop.

--- a/firestore.rules
+++ b/firestore.rules
@@ -59,7 +59,9 @@ service cloud.firestore {
     match /tables/{tableId}/hand/{docId} {
       allow read: if true;
       allow create, update: if request.auth != null
-        && onlyAllowedKeys(['handNo','dealerSeat','sbSeat','bbSeat','toActSeat','updatedAt']);
+        && request.resource.data.keys().subsetOf(
+             ['handNo','dealerSeat','sbSeat','bbSeat','toActSeat','updatedAt']
+           );
       allow delete: if false;
     }
 

--- a/public/table.html
+++ b/public/table.html
@@ -77,9 +77,17 @@
       const handStateRef = doc(db, 'tables', tableId, 'hand', 'state');
       if (window.jamlog) window.jamlog.push('hand.state.sub.start');
       unsubHandState = onSnapshot(handStateRef, (snap) => {
-        handState = snap.exists() ? snap.data() : null;
-        renderSeats();
-        if (window.jamlog) window.jamlog.push('hand.state.sub.ok', { handNo: handState?.handNo ?? null });
+        if (snap.exists()) {
+          handState = snap.data();
+          renderSeats();
+          if (window.jamlog) window.jamlog.push('hand.state.sub.ok', { handNo: handState?.handNo ?? 0 });
+        } else {
+          handState = null;
+          renderSeats();
+          if (window.jamlog) window.jamlog.push('hand.state.sub.empty');
+        }
+      }, (err) => {
+        if (window.jamlog) window.jamlog.push('hand.state.sub.error', { code: err?.code, message: err?.message });
       });
       onSnapshot(tableRef, (snap) => {
         debugLog('table.tableSnapshot', snap.exists());


### PR DESCRIPTION
## Summary
- allow authenticated players to write minimal hand state
- subscribe to hand state and log snapshot status with badges
- document brief-12b.execute completion

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/jampoker/package.json')*
- `(cd functions && npm test)` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c61727ea40832e90e33b8e2af737a0