### PR TITLE
12b rules: allow hand/state fields + log Start Hand payload keys

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -56,14 +56,27 @@ service cloud.firestore {
       }
     }
 
+    // Hand state for a table (single doc: tables/{tableId}/hand/state)
     match /tables/{tableId}/hand/{docId} {
+      // Anyone may read current hand markers
       allow read: if true;
+
+      // Authenticated clients may create/update with a strict key whitelist
       allow create, update: if request.auth != null
         && request.resource.data.keys().subsetOf([
-             'handNo','dealerSeat','sbSeat','bbSeat','toActSeat',
-             'street','betToMatchCents','commits','lastAggressorSeat',
-             'updatedAt'
-           ]);
+          'handNo',
+          'dealerSeat',
+          'sbSeat',
+          'bbSeat',
+          'toActSeat',
+          'street',
+          'betToMatchCents',
+          'commits',
+          'lastAggressorSeat',
+          'updatedAt'
+        ]);
+
+      // No deletes from clients
       allow delete: if false;
     }
 

--- a/public/admin.html
+++ b/public/admin.html
@@ -571,12 +571,31 @@
         let dealer;
         if (currentState && occupied.includes(currentState.dealerSeat)) dealer = next(occupied, currentState.dealerSeat);
         else dealer = occupied[0];
-        const sb = next(occupied, dealer);
-        const bb = next(occupied, sb);
-        const toAct = next(occupied, bb);
+        const sbSeat = next(occupied, dealer);
+        const bbSeat = next(occupied, sbSeat);
+        const toActSeat = next(occupied, bbSeat);
         const handNo = (typeof currentState?.handNo === 'number' ? currentState.handNo : 0) + 1;
-        await setDoc(stateRef, { handNo, dealerSeat: dealer, sbSeat: sb, bbSeat: bb, toActSeat: toAct, updatedAt: serverTimestamp() }, { merge: true });
-        if (window.jamlog) window.jamlog.push('hand.start.ok', { handNo, dealerSeat: dealer, sbSeat: sb, bbSeat: bb, toActSeat: toAct });
+        const tableData = tablesData[tableId] || {};
+        const sb = tableData?.blinds?.sbCents || 0;
+        const bb = tableData?.blinds?.bbCents || 0;
+        const commits = {};
+        commits[String(sbSeat)] = sb;
+        commits[String(bbSeat)] = bb;
+        const payload = {
+          handNo,
+          dealerSeat: dealer,
+          sbSeat,
+          bbSeat,
+          toActSeat,
+          street: 'preflop',
+          betToMatchCents: bb,
+          commits,
+          lastAggressorSeat: bbSeat,
+          updatedAt: serverTimestamp(),
+        };
+        if (window.jamlog) window.jamlog.push('hand.start.payload.keys', { keys: Object.keys(payload) });
+        await setDoc(stateRef, payload, { merge: true });
+        if (window.jamlog) window.jamlog.push('hand.start.ok', { handNo, dealerSeat: dealer, sbSeat, bbSeat, toActSeat, street: 'preflop' });
       } catch (err) {
         if (window.jamlog) window.jamlog.push('hand.start.fail', { code: err?.code, message: err?.message });
         alert('Error starting hand.');

--- a/public/table.html
+++ b/public/table.html
@@ -473,18 +473,20 @@
         commits[String(sbSeat)] = sb;
         commits[String(bbSeat)] = bb;
         foldedSeats.clear();
-        await setDoc(handRef, {
+        const payload = {
           handNo,
           dealerSeat: dealer,
           sbSeat,
           bbSeat,
+          toActSeat,
           street: 'preflop',
           betToMatchCents: bb,
           commits,
           lastAggressorSeat: bbSeat,
-          toActSeat,
           updatedAt: serverTimestamp(),
-        }, { merge: true });
+        };
+        if (window.jamlog) window.jamlog.push('hand.start.payload.keys', { keys: Object.keys(payload) });
+        await setDoc(handRef, payload, { merge: true });
         if (window.jamlog) window.jamlog.push('hand.start.ok', { handNo, dealerSeat: dealer, sbSeat, bbSeat, toActSeat, street: 'preflop' });
       } catch (err) {
         if (window.jamlog) window.jamlog.push('hand.start.fail', { code: err?.code, message: err?.message });


### PR DESCRIPTION
## Summary
- whitelist Start Hand fields under `tables/{id}/hand/state` in Firestore rules
- log Start Hand payload keys and write hand state in one set
- mirror Start Hand payload logging in admin panel

## Testing
- `cd functions && npm test` (fails: Missing script: "test")

------
https://chatgpt.com/codex/tasks/task_e_68c61c6dd218832e9be71471cc499e5c