### PR TITLE
12b: allow writes to tables/{id}/hand/state + rules probe

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -54,30 +54,30 @@ service cloud.firestore {
           && request.resource.data.seatIndex == resource.data.seatIndex; // seat index immutable
         allow delete: if false;
       }
-    }
 
-    // Hand state for a table (single doc: tables/{tableId}/hand/state)
-    match /tables/{tableId}/hand/{docId} {
-      // Anyone may read current hand markers
-      allow read: if true;
+      // per-table hand state (single doc: tables/{tableId}/hand/state)
+      match /hand/{docId} {
+        // Anyone can read current hand markers
+        allow read: if true;
 
-      // Authenticated clients may create/update with a strict key whitelist
-      allow create, update: if request.auth != null
-        && request.resource.data.keys().subsetOf([
-          'handNo',
-          'dealerSeat',
-          'sbSeat',
-          'bbSeat',
-          'toActSeat',
-          'street',
-          'betToMatchCents',
-          'commits',
-          'lastAggressorSeat',
-          'updatedAt'
-        ]);
+        // Authenticated clients can create/update with a strict key whitelist
+        allow create, update: if request.auth != null
+          && request.resource.data.keys().subsetOf([
+            'handNo',
+            'dealerSeat',
+            'sbSeat',
+            'bbSeat',
+            'toActSeat',
+            'street',
+            'betToMatchCents',
+            'commits',
+            'lastAggressorSeat',
+            'updatedAt'
+          ]);
 
-      // No deletes from clients
-      allow delete: if false;
+        // No client deletes
+        allow delete: if false;
+      }
     }
 
     // Hands are server-managed only.

--- a/public/table.html
+++ b/public/table.html
@@ -242,7 +242,8 @@
       const desyncLine = seatCountDesync ? `<div class="small">Players seated: ${derivedSeatCount} (active: ${activeSeatCount})</div>` : '';
       const current = getCurrentPlayer();
       const showStart = (current && seatData.some(s => s.occupiedBy === current.id)) || isDebug();
-      const startBtnHtml = showStart ? `<div style="margin-top:8px;text-align:right;"><button id="btn-start-hand" class="small">Start Hand</button></div>` : '';
+      const probeBtnHtml = isDebug() ? `<button id="btn-rules-probe" class="small" style="margin-left:8px;">Rules Probe</button>` : '';
+      const startBtnHtml = showStart ? `<div style="margin-top:8px;text-align:right;"><button id="btn-start-hand" class="small">Start Hand</button>${probeBtnHtml}</div>` : '';
       infoEl.innerHTML = `
         <h1>${t.name || '(no name)'}</h1>
         <div class="small">Blinds: ${blindStr}</div>
@@ -253,6 +254,7 @@
       `;
       if (showStart) {
         document.getElementById('btn-start-hand')?.addEventListener('click', startHand);
+        document.getElementById('btn-rules-probe')?.addEventListener('click', () => rulesProbe(tableId));
       }
     }
 
@@ -491,6 +493,16 @@
       } catch (err) {
         if (window.jamlog) window.jamlog.push('hand.start.fail', { code: err?.code, message: err?.message });
         alert('Error starting hand.');
+      }
+    }
+
+    async function rulesProbe(tableId) {
+      const probeRef = doc(db, 'tables', tableId, 'hand', '_probe');
+      try {
+        await setDoc(probeRef, { updatedAt: serverTimestamp() }, { merge: true });
+        if (window.jamlog) window.jamlog.push('hand.rules.probe.ok');
+      } catch (e) {
+        if (window.jamlog) window.jamlog.push('hand.rules.probe.fail', { code: e.code, message: e.message });
       }
     }
 


### PR DESCRIPTION
## Summary
- whitelist hand state fields in Firestore rules so authenticated clients can create or update tables/{tableId}/hand/state
- add dev-only Rules Probe button for one-tap confirmation of deployed rules

## Checklist
- [x] firestore.rules includes match /tables/{tableId}/hand/{docId} with allowed keys.
- [x] Start Hand unchanged except for payload keys log.
- [x] Optional Rules Probe button logs hand.rules.probe.ok|fail.
- [x] No other rule/index changes.


------
https://chatgpt.com/codex/tasks/task_e_68c62009f220832e908b425aa34ae1a2