### PR TITLE
12b: wire & deploy hand/state rules + Rules Probe

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "jampoker",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "deploy:rules": "firebase deploy --only firestore:rules --project jam-poker"
+  }
+}

--- a/public/admin.html
+++ b/public/admin.html
@@ -183,7 +183,7 @@
   <script type="module" src="/firebase-init.js"></script>
   <script type="module">
     import { app } from "/firebase-init.js";
-    import { db, dollars, parseDollarsToCents, renderCurrentPlayerControls, isDebug } from "/common.js";
+    import { db, dollars, parseDollarsToCents, renderCurrentPlayerControls, isDebug, toast } from "/common.js";
       import {
         collection, addDoc, serverTimestamp, query, orderBy, onSnapshot, where,
         doc, updateDoc, deleteDoc, setDoc, writeBatch, getDocs, getDoc
@@ -598,7 +598,7 @@
         if (window.jamlog) window.jamlog.push('hand.start.ok', { handNo, dealerSeat: dealer, sbSeat, bbSeat, toActSeat, street: 'preflop' });
       } catch (err) {
         if (window.jamlog) window.jamlog.push('hand.start.fail', { code: err?.code, message: err?.message });
-        alert('Error starting hand.');
+        toast('Cannot start hand: Firestore rules not deployed for hand/state.');
       }
     }
 

--- a/public/common.js
+++ b/public/common.js
@@ -145,4 +145,20 @@ export function showSeatsDebug(tableId, seatDocs) {
   box.textContent = `debug.tableId=${tableId}\n${paths}`;
 }
 
+export function toast(msg) {
+  const el = document.createElement('div');
+  el.textContent = msg;
+  el.style.position = 'fixed';
+  el.style.bottom = '20px';
+  el.style.left = '50%';
+  el.style.transform = 'translateX(-50%)';
+  el.style.background = '#7f1d1d';
+  el.style.color = 'white';
+  el.style.padding = '8px 12px';
+  el.style.borderRadius = '8px';
+  el.style.zIndex = '9999';
+  document.body.appendChild(el);
+  setTimeout(() => el.remove(), 4000);
+}
+
 

--- a/public/table.html
+++ b/public/table.html
@@ -26,7 +26,7 @@
   <script type="module" src="/firebase-init.js"></script>
   <script type="module">
     import { app } from "/firebase-init.js";
-    import { db, dollars, formatCents, renderCurrentPlayerControls, isDebug, setDebug, getCurrentPlayer, formatCard, stageLabel, showSeatsDebug, debugLog } from "/common.js";
+    import { db, dollars, formatCents, renderCurrentPlayerControls, isDebug, setDebug, getCurrentPlayer, formatCard, stageLabel, showSeatsDebug, debugLog, toast } from "/common.js";
     import {
       doc, setDoc, updateDoc, onSnapshot, collection, query, orderBy, serverTimestamp,
       writeBatch, runTransaction, increment, getDoc
@@ -242,8 +242,8 @@
       const desyncLine = seatCountDesync ? `<div class="small">Players seated: ${derivedSeatCount} (active: ${activeSeatCount})</div>` : '';
       const current = getCurrentPlayer();
       const showStart = (current && seatData.some(s => s.occupiedBy === current.id)) || isDebug();
-      const probeBtnHtml = isDebug() ? `<button id="btn-rules-probe" class="small" style="margin-left:8px;">Rules Probe</button>` : '';
-      const startBtnHtml = showStart ? `<div style="margin-top:8px;text-align:right;"><button id="btn-start-hand" class="small">Start Hand</button>${probeBtnHtml}</div>` : '';
+      const probeHtml = isDebug() ? `<div style="margin-top:8px;"><button id="rules-probe" class="small">Rules Probe</button><div id="rules-status" class="small mono"></div></div>` : '';
+      const startBtnHtml = showStart ? `<div style="margin-top:8px;text-align:right;"><button id="btn-start-hand" class="small">Start Hand</button></div>${probeHtml}` : probeHtml;
       infoEl.innerHTML = `
         <h1>${t.name || '(no name)'}</h1>
         <div class="small">Blinds: ${blindStr}</div>
@@ -254,8 +254,8 @@
       `;
       if (showStart) {
         document.getElementById('btn-start-hand')?.addEventListener('click', startHand);
-        document.getElementById('btn-rules-probe')?.addEventListener('click', () => rulesProbe(tableId));
       }
+      document.getElementById('rules-probe')?.addEventListener('click', () => rulesProbe(tableId));
     }
 
     function renderHand() {
@@ -492,17 +492,20 @@
         if (window.jamlog) window.jamlog.push('hand.start.ok', { handNo, dealerSeat: dealer, sbSeat, bbSeat, toActSeat, street: 'preflop' });
       } catch (err) {
         if (window.jamlog) window.jamlog.push('hand.start.fail', { code: err?.code, message: err?.message });
-        alert('Error starting hand.');
+        toast('Cannot start hand: Firestore rules not deployed for hand/state.');
       }
     }
 
     async function rulesProbe(tableId) {
       const probeRef = doc(db, 'tables', tableId, 'hand', '_probe');
+      const statusEl = document.getElementById('rules-status');
       try {
         await setDoc(probeRef, { updatedAt: serverTimestamp() }, { merge: true });
         if (window.jamlog) window.jamlog.push('hand.rules.probe.ok');
+        if (statusEl) statusEl.textContent = 'Rules Probe: OK (hand/state write allowed)';
       } catch (e) {
         if (window.jamlog) window.jamlog.push('hand.rules.probe.fail', { code: e.code, message: e.message });
+        if (statusEl) statusEl.textContent = `Rules Probe: FAIL ${e.code} ${e.message}`;
       }
     }
 


### PR DESCRIPTION
## Summary
- export toast helper and use it to show hand start guard messages
- add Rules Probe panel for hand/state write checks
- include deploy:rules script for Firestore rules deployment

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c622c53e78832ebf93e05ad51e4a57