### PR TITLE
ci-12b — Deploy Firestore rules independently & stabilize Hosting Preview

### DIFF
--- a/.github/workflows/deploy-rules.yml
+++ b/.github/workflows/deploy-rules.yml
@@ -1,0 +1,20 @@
+name: Deploy Firestore Rules
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch: {}
+
+jobs:
+  deploy-rules:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Firebase CLI
+        run: npm i -g firebase-tools@latest
+      - name: Deploy rules only
+        env:
+          FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
+        run: |
+          firebase use jam-poker --token "$FIREBASE_TOKEN"
+          firebase deploy --only firestore:rules --project jam-poker --non-interactive --token "$FIREBASE_TOKEN"

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -13,8 +13,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Cleanup stale preview channels (>3d)
+        env:
+          FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
+        run: |
+          npm i -g firebase-tools@latest
+          npx firebase-tools hosting:channels:list --site jam-poker --project jam-poker --json > channels.json
+          node -e "const fs=require('fs');const x=JSON.parse(fs.readFileSync('channels.json','utf8'));const now=Date.now();const stale=(x.result||[]).filter(c=>c.expireTime && new Date(c.expireTime).getTime()<now).map(c=>c.name.split('/').pop());for(const id of stale){console.log('Deleting',id);}" 
+          for id in $(node -e "const fs=require('fs');const x=JSON.parse(fs.readFileSync('channels.json','utf8'));const now=Date.now();const stale=(x.result||[]).filter(c=>c.expireTime && new Date(c.expireTime).getTime()<now).map(c=>c.name.split('/').pop());console.log(stale.join(' '))"); do
+            [ -z "$id" ] || npx firebase-tools hosting:channel:delete "$id" --site jam-poker --project jam-poker --force
+          done
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           repoToken: ${{ secrets.GITHUB_TOKEN }}
           firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JAM_POKER }}
           projectId: jam-poker
+          channelId: pr-${{ github.event.pull_request.number }}
+          expires: 3d
+

--- a/firebase.json
+++ b/firebase.json
@@ -1,6 +1,6 @@
 {
   "hosting": {
-    "site": "jampoker",
+    "site": "jam-poker",
     "public": "public",
     "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
     "rewrites": [


### PR DESCRIPTION
## Summary
- Configure Firebase Hosting to use the `jam-poker` site and include Firestore rules and indexes.
- Add `deploy-rules` workflow to deploy Firestore security rules independently.
- Stabilize Hosting preview channels and clean up expired channels before deploying.

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npm --prefix functions run build`


------
https://chatgpt.com/codex/tasks/task_e_68c625ef8aa4832e909be1faf3cdf3b9