### PR TITLE
ci-12b: fix hosting preview quota and deploy rules

### DIFF
--- a/.github/workflows/deploy-rules.yml
+++ b/.github/workflows/deploy-rules.yml
@@ -1,0 +1,19 @@
+name: Deploy Firestore Rules
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch: {}
+
+jobs:
+  deploy-rules:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Firebase CLI
+        run: npm i -g firebase-tools@latest
+      - name: Deploy rules only
+        env:
+          FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
+        run: |
+          firebase use jam-poker --token "$FIREBASE_TOKEN"
+          firebase deploy --only firestore:rules --project jam-poker --non-interactive --token "$FIREBASE_TOKEN"

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -13,8 +13,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Cleanup stale preview channels (>expired)
+        env:
+          FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
+        run: |
+          npx firebase-tools@latest hosting:channel:list --site jam-poker --project jam-poker --json > channels.json
+          node -e "const fs=require('fs');const j=JSON.parse(fs.readFileSync('channels.json','utf8'));const now=Date.now();const ids=(j.result||[]).filter(c=>c.expireTime && new Date(c.expireTime).getTime()<now).map(c=>c.name.split('/').pop());console.log('Stale:', ids);fs.writeFileSync('stale.txt', ids.join('\n'));"
+          if [ -s stale.txt ]; then
+            while IFS= read -r id; do
+              [ -z "$id" ] || npx firebase-tools@latest hosting:channel:delete "$id" --site jam-poker --project jam-poker --force
+            done < stale.txt
+          fi
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:
-          repoToken: ${{ secrets.GITHUB_TOKEN }}
-          firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JAM_POKER }}
+          repoToken: '${{ secrets.GITHUB_TOKEN }}'
+          firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_JAM_POKER }}'
           projectId: jam-poker
+          channelId: pr-${{ github.event.pull_request.number }}
+          expires: 3d

--- a/firebase.json
+++ b/firebase.json
@@ -1,6 +1,6 @@
 {
   "hosting": {
-    "site": "jampoker",
+    "site": "jam-poker",
     "public": "public",
     "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
     "rewrites": [


### PR DESCRIPTION
## Summary
- wire firebase config to jam-poker site and ensure rules/indexes are referenced
- add workflow to deploy Firestore rules alone
- stabilize PR preview channel and clean up stale channels

## Testing
- `npm --prefix functions run build`

------
https://chatgpt.com/codex/tasks/task_e_68c6287a11dc832eba843ce527e00286