### PR TITLE
ci: cleanup hosting previews and add rules deploy workflow

### DIFF
--- a/.github/workflows/deploy-rules.yml
+++ b/.github/workflows/deploy-rules.yml
@@ -1,0 +1,15 @@
+name: Deploy Firestore Rules
+on:
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Deploy rules only
+        env:
+          FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
+        run: |
+          npm i -g firebase-tools@latest
+          firebase deploy --only firestore:rules --project jam-poker --non-interactive --token "$FIREBASE_TOKEN"

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -13,8 +13,31 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Cleanup stale preview channels (>expired)
+        env:
+          FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
+        run: |
+          set -e
+          # List channels (singular subcommand; correct site id; pass token)
+          npx firebase-tools@latest hosting:channel:list \
+            --site jampoker --project jam-poker --json --token "$FIREBASE_TOKEN" > channels.json \
+            || { echo "channel:list failed (non-blocking)"; exit 0; }
+
+          # Compute expired channels
+          node -e "const fs=require('fs');const j=JSON.parse(fs.readFileSync('channels.json','utf8'));const now=Date.now();const ids=(j.result||[]).filter(c=>c.expireTime && new Date(c.expireTime).getTime()<now).map(c=>c.name.split('/').pop());console.log('Stale:', ids);fs.writeFileSync('stale.txt', ids.join('\\n'));"
+
+          # Delete expired channels (non-blocking on errors)
+          if [ -s stale.txt ]; then
+            while IFS= read -r id; do
+              [ -z "$id" ] || npx firebase-tools@latest hosting:channel:delete \
+                "$id" --site jampoker --project jam-poker --force --token "$FIREBASE_TOKEN" \
+                || echo "delete failed for $id (continuing)"
+            done < stale.txt
+          fi
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           repoToken: ${{ secrets.GITHUB_TOKEN }}
           firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JAM_POKER }}
           projectId: jam-poker
+          channelId: pr-${{ github.event.pull_request.number }}
+          expires: 3d


### PR DESCRIPTION
## Summary
- Soft-failing cleanup script authenticates with FIREBASE_TOKEN and targets the jampoker site
- Deploy Firestore rules in a standalone workflow using FIREBASE_TOKEN

## Testing
- `npm --prefix functions test` (fails: Missing script "test")
- `npm --prefix functions run build`


------
https://chatgpt.com/codex/tasks/task_e_68c62a17df2c832e82fae43b5573b101