### PR TITLE
feat: authorize table admins to start hands

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -6,6 +6,15 @@ service cloud.firestore {
       return request.auth != null && request.auth.token.admin == true;
     }
 
+    function tableDoc(tableId) {
+      return get(/databases/$(database)/documents/tables/$(tableId));
+    }
+    function isTableAdmin(tableId) {
+      return request.auth != null &&
+             tableDoc(tableId).data.createdByUid != null &&
+             tableDoc(tableId).data.createdByUid == request.auth.uid;
+    }
+
     // Helpers for key shape validation
     function onlyAllowedKeys(allowed) {
       return request.resource.data.keys().hasOnly(allowed);
@@ -27,7 +36,7 @@ service cloud.firestore {
       // Dev-safe create: any authenticated user (anon OK) may create a table but only with whitelisted keys
       allow create: if request.auth != null
         && hasAllKeys(['active','createdAt','maxSeats','activeSeatCount','gameType','blinds','buyIn'])
-        && onlyAllowedKeys(['name','active','createdAt','maxSeats','activeSeatCount','gameType','blinds','buyIn','deletedAt'])
+        && onlyAllowedKeys(['name','active','createdAt','maxSeats','activeSeatCount','gameType','blinds','buyIn','deletedAt','createdByUid'])
         && request.resource.data.active is bool
         && request.resource.data.maxSeats is int
         && request.resource.data.activeSeatCount is int
@@ -37,7 +46,11 @@ service cloud.firestore {
       // Update: players may ONLY change activeSeatCount; admins may archive (active/deletedAt)
       allow update: if (request.auth != null
                         && request.resource.data.diff(resource.data).changedKeys().hasOnly(['activeSeatCount']))
-                    || (isAdmin() && request.resource.data.diff(resource.data).changedKeys().hasOnly(['active','deletedAt']));
+                    || (isAdmin() && request.resource.data.diff(resource.data).changedKeys().hasOnly(['active','deletedAt']))
+                    || (request.auth != null
+                        && resource.data.createdByUid == null
+                        && request.resource.data.diff(resource.data).changedKeys().hasOnly(['createdByUid'])
+                        && request.resource.data.createdByUid == request.auth.uid);
 
       // Delete: keep admin-only
       allow delete: if isAdmin();
@@ -60,8 +73,7 @@ service cloud.firestore {
         // Anyone can read current hand markers
         allow read: if true;
 
-        // Authenticated clients can create/update with a strict key whitelist
-        allow create, update: if request.auth != null
+        allow create: if request.auth != null
           && request.resource.data.keys().subsetOf([
             'handNo',
             'dealerSeat',
@@ -73,7 +85,22 @@ service cloud.firestore {
             'commits',
             'lastAggressorSeat',
             'updatedAt'
-          ]);
+          ])
+          && (isTableAdmin(tableId) || tableDoc(tableId).data.createdByUid == null);
+        allow update: if request.auth != null
+          && request.resource.data.keys().subsetOf([
+            'handNo',
+            'dealerSeat',
+            'sbSeat',
+            'bbSeat',
+            'toActSeat',
+            'street',
+            'betToMatchCents',
+            'commits',
+            'lastAggressorSeat',
+            'updatedAt'
+          ])
+          && isTableAdmin(tableId);
 
         // No client deletes
         allow delete: if false;

--- a/public/admin.html
+++ b/public/admin.html
@@ -350,6 +350,8 @@
       if (window.jamlog) window.jamlog.push('admin.create.start', { numericOk, keys: ['name','active','createdAt','maxSeats','activeSeatCount','gameType','blinds','buyIn'] });
 
       tStatus.textContent = "Creating…"; tBtn.disabled = true;
+      const u = auth.currentUser;
+      const createdByUid = u?.uid || null;
       const payload = {
         name,
         active: true,
@@ -359,6 +361,7 @@
         gameType: 'holdem',
         blinds: { sbCents: sbC, bbCents: bbC },
         buyIn: { minCents: minC, maxCents: maxC, defaultCents: defC },
+        createdByUid,
       };
       const types = {};
       Object.keys(payload).forEach(k => {
@@ -482,16 +485,22 @@
           const blindStr = `${dollars(sb)}/${dollars(bb)}`;
           const rangeStr = `${dollars(minB)}–${dollars(maxB)} (${dollars(defB)})`;
           const seated = seatCounts[id] || 0;
+          const ownerUid = d.createdByUid || null;
+          const ownerBadge = `<div class="small">Owner: ${ownerUid ? (auth.currentUser && ownerUid === auth.currentUser.uid ? 'you' : 'other') : '—'}</div>`;
+          const actions = [
+            `<a href="/table.html?id=${id}" style="padding:4px 8px;border-radius:8px;border:1px solid #334155;background:#0ea5e9;color:white;font-size:12px;text-decoration:none;">Open</a>`,
+            `<button class="start-hand" style="padding:4px 8px;border-radius:8px;border:1px solid #334155;background:#3b82f6;color:white;font-size:12px;cursor:pointer;">Start Hand</button>`,
+            `<button class="archive-table" style="padding:4px 8px;border-radius:8px;border:1px solid #7f1d1d;background:#ef4444;color:white;font-size:12px;cursor:pointer;">Archive</button>`
+          ];
+          if (!ownerUid && auth.currentUser) {
+            actions.push(`<button class="set-admin" style="padding:4px 8px;border-radius:8px;border:1px solid #334155;background:#10b981;color:white;font-size:12px;cursor:pointer;">Set me as admin</button>`);
+          }
           return `<tr data-id="${id}">
-          <td style="padding:8px;border-bottom:1px solid #334155;"><div style="font-weight:600">${d.name || "(no name)"}</div><div class="small"><code>${id}</code></div></td>
+          <td style="padding:8px;border-bottom:1px solid #334155;"><div style="font-weight:600">${d.name || "(no name)"}</div><div class="small"><code>${id}</code></div>${ownerBadge}</td>
           <td style="padding:8px;border-bottom:1px solid #334155;">${blindStr}</td>
           <td style="padding:8px;border-bottom:1px solid #334155;">${rangeStr}</td>
           <td style="padding:8px;border-bottom:1px solid #334155;">${seated}</td>
-          <td style="padding:8px;border-bottom:1px solid #334155;text-align:right;">
-            <a href="/table.html?id=${id}" style="padding:4px 8px;border-radius:8px;border:1px solid #334155;background:#0ea5e9;color:white;font-size:12px;text-decoration:none;">Open</a>
-            <button class="start-hand" style="padding:4px 8px;border-radius:8px;border:1px solid #334155;background:#3b82f6;color:white;font-size:12px;cursor:pointer;">Start Hand</button>
-            <button class="archive-table" style="padding:4px 8px;border-radius:8px;border:1px solid #7f1d1d;background:#ef4444;color:white;font-size:12px;cursor:pointer;">Archive</button>
-          </td>
+          <td style="padding:8px;border-bottom:1px solid #334155;text-align:right;">${actions.join(' ')}</td>
         </tr>`;
         });
       if (rows.length === 0) {
@@ -623,6 +632,13 @@
         }
       } else if (target.classList.contains("start-hand")) {
         await startHand(id);
+      } else if (target.classList.contains("set-admin")) {
+        try {
+          await updateDoc(doc(db, 'tables', id), { createdByUid: auth.currentUser.uid });
+          alert('Set as admin.');
+        } catch (err) {
+          alert('Error: ' + (err?.message || err));
+        }
       }
     });
 

--- a/public/table.html
+++ b/public/table.html
@@ -31,7 +31,9 @@
       doc, setDoc, updateDoc, onSnapshot, collection, query, orderBy, serverTimestamp,
       writeBatch, runTransaction, increment, getDoc
     } from "https://www.gstatic.com/firebasejs/10.12.5/firebase-firestore.js";
-    import { awaitAuthReady } from "/auth.js";
+    import { awaitAuthReady, auth } from "/auth.js";
+
+    const shortUid = (uid) => uid ? uid.slice(0, 6) : 'null';
 
     if (window.jamlog && isDebug()) {
       window.jamlog.init({ projectId: app.options.projectId, build: window.__BUILD_SHA__ || 'dev', page: 'TABLE' });
@@ -227,7 +229,7 @@
       }
     }
 
-    function renderTableInfo() {
+    async function renderTableInfo() {
       if (!tableData) { infoEl.textContent = ''; return; }
       const t = tableData;
       const sb = t?.blinds?.sbCents ?? t.smallBlindCents ?? 0;
@@ -240,10 +242,8 @@
       const derivedSeatCount = seatData.filter(s => s.occupiedBy).length;
       const activeSeatCount = t.activeSeatCount ?? 0;
       const desyncLine = seatCountDesync ? `<div class="small">Players seated: ${derivedSeatCount} (active: ${activeSeatCount})</div>` : '';
-      const current = getCurrentPlayer();
-      const showStart = (current && seatData.some(s => s.occupiedBy === current.id)) || isDebug();
       const probeBtnHtml = isDebug() ? `<button id="btn-rules-probe" class="small" style="margin-left:8px;">Rules Probe</button>` : '';
-      const startBtnHtml = showStart ? `<div style="margin-top:8px;text-align:right;"><button id="btn-start-hand" class="small">Start Hand</button>${probeBtnHtml}</div>` : '';
+      const startBtnHtml = `<div id="start-hand-wrap" style="margin-top:8px;text-align:right;"><button id="btn-start-hand" class="small">Start Hand</button>${probeBtnHtml}<div id="start-hand-hint" class="small" style="margin-top:4px;display:none;"></div></div>`;
       infoEl.innerHTML = `
         <h1>${t.name || '(no name)'}</h1>
         <div class="small">Blinds: ${blindStr}</div>
@@ -252,9 +252,30 @@
         ${desyncLine}
         ${startBtnHtml}
       `;
-      if (showStart) {
-        document.getElementById('btn-start-hand')?.addEventListener('click', startHand);
-        document.getElementById('btn-rules-probe')?.addEventListener('click', () => rulesProbe(tableId));
+      document.getElementById('btn-rules-probe')?.addEventListener('click', () => rulesProbe(tableId));
+      const startBtn = document.getElementById('btn-start-hand');
+      const hintEl = document.getElementById('start-hand-hint');
+      startBtn.disabled = true;
+      let enable = false;
+      await awaitAuthReady();
+      const uid = auth.currentUser?.uid || null;
+      if (!t.createdByUid || (uid && t.createdByUid === uid)) {
+        if (derivedSeatCount >= 2) {
+          enable = true;
+        } else {
+          startBtn.title = 'Need 2+ players';
+        }
+      } else {
+        const msg = `Only the table owner can start a hand. Owner: ${shortUid(t.createdByUid)}`;
+        startBtn.title = msg;
+        hintEl.textContent = msg;
+        hintEl.style.display = '';
+        if (window.jamlog) window.jamlog.push('hand.start.disabled', { reason: 'not-admin' });
+      }
+      startBtn.disabled = !enable;
+      if (enable) {
+        startBtn.removeAttribute('title');
+        startBtn.addEventListener('click', startHand);
       }
     }
 


### PR DESCRIPTION
## Summary
- store table creator as `createdByUid` and allow backfilling admin on existing tables
- tighten Firestore rules to permit hand-state writes only by table admins
- gate the Start Hand button to the table owner with a helpful hint

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c6606c162c832eaf9c4df2bd3de46b