### PR TITLE
feat: add street progression and action gating

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -71,8 +71,48 @@ service cloud.firestore {
       // Canonical hand state path:
       match /handState/{docId} {
         allow read: if true;
-        allow create, update: if isTableAdmin(tableId);
-        allow delete: if isTableAdmin(tableId);
+
+        function streetToNum(s) {
+          return s == 'preflop' ? 0
+               : s == 'flop' ? 1
+               : s == 'turn' ? 2
+               : 3;
+        }
+
+        function actorIs(tableId, seat) {
+          return request.auth != null &&
+                 get(/databases/$(database)/documents/tables/$(tableId)/seats/$(seat))
+                   .data.occupiedBy == request.auth.uid;
+        }
+
+        function isCheck(tableId) {
+          let seat = resource.data.toActSeat;
+          let bet = resource.data.betToMatchCents;
+          let oldCommit = resource.data.commits[seat] ?? 0;
+          let newCommit = request.resource.data.commits[seat] ?? oldCommit;
+          let delta = newCommit - oldCommit;
+          return actorIs(tableId, seat) && bet == oldCommit && delta == 0 &&
+                 request.resource.data.diff(resource.data).changedKeys()
+                   .hasOnly(['toActSeat','updatedAt','street','lastAggressorSeat','betToMatchCents']) &&
+                 streetToNum(request.resource.data.street) >= streetToNum(resource.data.street) &&
+                 request.resource.data.toActSeat != resource.data.toActSeat;
+        }
+
+        function isCall(tableId) {
+          let seat = resource.data.toActSeat;
+          let bet = resource.data.betToMatchCents;
+          let oldCommit = resource.data.commits[seat] ?? 0;
+          let newCommit = request.resource.data.commits[seat] ?? 0;
+          let delta = newCommit - oldCommit;
+          return actorIs(tableId, seat) && delta == bet - oldCommit && delta >= 0 &&
+                 request.resource.data.diff(resource.data).changedKeys()
+                   .hasOnly(['toActSeat','updatedAt','commits','street','lastAggressorSeat','betToMatchCents']) &&
+                 streetToNum(request.resource.data.street) >= streetToNum(resource.data.street) &&
+                 request.resource.data.toActSeat != resource.data.toActSeat;
+        }
+
+        allow update: if isCheck(tableId) || isCall(tableId);
+        allow create, delete: if isTableAdmin(tableId);
       }
     }
 

--- a/src/poker/handMath.ts
+++ b/src/poker/handMath.ts
@@ -1,0 +1,83 @@
+export type Street = 'preflop' | 'flop' | 'turn' | 'river';
+
+export interface HandState {
+  street: Street;
+  toActSeat: number | null;
+  dealerSeat?: number | null;
+  betToMatchCents: number;
+  commits: Record<number, number>;
+  activeSeats?: number[]; // optional list of active seat indexes
+  folded?: Record<number, boolean>;
+  lastAggressorSeat?: number | null;
+}
+
+export function computeToCall(hand: HandState, seat: number): number {
+  const committed = hand.commits?.[seat] ?? 0;
+  return Math.max(0, (hand.betToMatchCents || 0) - committed);
+}
+
+export function computeLegalActions(hand: HandState, seat: number) {
+  const toCall = computeToCall(hand, seat);
+  return {
+    check: toCall === 0,
+    call: toCall > 0,
+  };
+}
+
+function seatsInOrder(hand: HandState): number[] {
+  if (hand.activeSeats && hand.activeSeats.length) {
+    return [...hand.activeSeats].sort((a, b) => a - b);
+  }
+  return Object.keys(hand.commits || {})
+    .map((k) => parseInt(k, 10))
+    .sort((a, b) => a - b);
+}
+
+export function nextToAct(hand: HandState, fromSeat?: number | null): number | null {
+  const seats = seatsInOrder(hand);
+  if (seats.length === 0) return null;
+  const start = fromSeat ?? hand.toActSeat ?? seats[0];
+  const startIdx = seats.indexOf(start);
+  for (let i = 1; i <= seats.length; i++) {
+    const seat = seats[(startIdx + i) % seats.length];
+    if (hand.folded && hand.folded[seat]) continue;
+    return seat;
+  }
+  return null;
+}
+
+export function nextStreet(street: Street): Street {
+  switch (street) {
+    case 'preflop':
+      return 'flop';
+    case 'flop':
+      return 'turn';
+    case 'turn':
+      return 'river';
+    default:
+      return 'river';
+  }
+}
+
+export function firstToActOnNextStreet(hand: HandState): number | null {
+  if (hand.dealerSeat == null) return nextToAct(hand);
+  return nextToAct(hand, hand.dealerSeat);
+}
+
+export function everyoneMatched(hand: HandState): boolean {
+  const seats = seatsInOrder(hand);
+  const target = hand.betToMatchCents || 0;
+  return seats.every((seat) => (hand.commits?.[seat] ?? 0) >= target);
+}
+
+export function maybeAdvanceStreet(hand: HandState) {
+  if (everyoneMatched(hand)) {
+    return {
+      street: nextStreet(hand.street),
+      betToMatchCents: 0,
+      lastAggressorSeat: null,
+      toActSeat: firstToActOnNextStreet(hand),
+    } as Partial<HandState>;
+  }
+  return { toActSeat: nextToAct(hand) } as Partial<HandState>;
+}

--- a/src/poker/tx/call.ts
+++ b/src/poker/tx/call.ts
@@ -1,0 +1,24 @@
+import { runTransaction, serverTimestamp } from 'firebase/firestore';
+import { computeToCall, HandState, maybeAdvanceStreet } from '../handMath';
+
+export async function call(db: any, handRef: any): Promise<void> {
+  await runTransaction(db, async (tx: any) => {
+    const snap = await tx.get(handRef);
+    const hand = snap.data() as HandState;
+    if (!hand) throw new Error('missing-hand');
+    const seat = hand.toActSeat as number;
+    const toCall = computeToCall(hand, seat);
+    if (toCall <= 0) throw new Error('no-call');
+    const newCommit = (hand.commits?.[seat] ?? 0) + toCall;
+    const after: HandState = {
+      ...hand,
+      commits: { ...hand.commits, [seat]: newCommit },
+    };
+    const advance = maybeAdvanceStreet(after);
+    tx.update(handRef, {
+      [`commits.${seat}`]: newCommit,
+      ...advance,
+      updatedAt: serverTimestamp(),
+    });
+  });
+}

--- a/src/poker/tx/check.ts
+++ b/src/poker/tx/check.ts
@@ -1,0 +1,15 @@
+import { runTransaction, serverTimestamp } from 'firebase/firestore';
+import { computeToCall, HandState, maybeAdvanceStreet } from '../handMath';
+
+export async function check(db: any, handRef: any): Promise<void> {
+  await runTransaction(db, async (tx: any) => {
+    const snap = await tx.get(handRef);
+    const hand = snap.data() as HandState;
+    if (!hand) throw new Error('missing-hand');
+    const seat = hand.toActSeat;
+    const toCall = computeToCall(hand, seat ?? -1);
+    if (toCall > 0) throw new Error('now-must-call');
+    const advance = maybeAdvanceStreet(hand);
+    tx.update(handRef, { ...advance, updatedAt: serverTimestamp() });
+  });
+}

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -1,0 +1,10 @@
+export type TelemetryEvent = string;
+export type TelemetryPayload = Record<string, unknown>;
+
+export function telemetry(event: TelemetryEvent, payload: TelemetryPayload = {}): void {
+  if (typeof window !== 'undefined' && (window as any).jamlog) {
+    (window as any).jamlog.push(event, payload);
+  } else {
+    console.log(event, payload); // fallback for non-browser environments
+  }
+}

--- a/src/ui/TableActions.tsx
+++ b/src/ui/TableActions.tsx
@@ -1,0 +1,67 @@
+import React, { useState } from 'react';
+import { computeToCall, computeLegalActions, HandState } from '../poker/handMath';
+import { telemetry } from '../telemetry';
+
+export interface TableActionsProps {
+  hand?: HandState | null;
+  mySeat: number | null;
+  onCheck: () => Promise<void>;
+  onCall: (toCall: number) => Promise<void>;
+}
+
+export const TableActions: React.FC<TableActionsProps> = ({ hand, mySeat, onCheck, onCall }) => {
+  const [locked, setLocked] = useState(false);
+  if (hand == null || mySeat == null) return null;
+
+  const toCall = computeToCall(hand, mySeat);
+  const legal = computeLegalActions(hand, mySeat);
+  const isActor = hand.toActSeat === mySeat;
+  const disabled = locked || !isActor;
+  const label = toCall === 0 ? 'Check' : `Call $${(toCall / 100).toFixed(2)}`;
+
+  const guardFail = (type: 'check' | 'call', reason: string) => {
+    telemetry(`action.${type}.fail`, { toCall, reason });
+  };
+
+  const lock = () => {
+    setLocked(true);
+    setTimeout(() => setLocked(false), 600);
+  };
+
+  const handleCheck = async () => {
+    if (!isActor) return guardFail('check', 'not-your-turn');
+    if (!legal.check) return guardFail('check', 'now-must-call');
+    telemetry('action.check.start', { toCall });
+    lock();
+    try {
+      await onCheck();
+      telemetry('action.check.ok', { toCall });
+    } catch (e: any) {
+      telemetry('action.check.fail', { toCall, reason: e?.message || 'error' });
+    }
+  };
+
+  const handleCall = async () => {
+    if (!isActor) return guardFail('call', 'not-your-turn');
+    if (!legal.call) return guardFail('call', 'no-call');
+    telemetry('action.call.start', { toCall });
+    lock();
+    try {
+      await onCall(toCall);
+      telemetry('action.call.ok', { toCall });
+    } catch (e: any) {
+      telemetry('action.call.fail', { toCall, reason: e?.message || 'error' });
+    }
+  };
+
+  return (
+    <div>
+      <button disabled={disabled || !legal.check} onClick={handleCheck}>
+        Check
+      </button>
+      <button disabled={disabled || !legal.call} onClick={handleCall}>
+        {label}
+      </button>
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary
- add shared hand math utilities for to-call, action legality, and street progression
- implement action buttons with gating, telemetry, and in-flight lock
- update Firestore rules and server transactions for check/call logic

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68c668b85b84832e93bc326a776f0eb7