### PR TITLE
fix: make Firestore rules compile without optional chaining

### DIFF
--- a/.github/workflows/deploy-rules.yml
+++ b/.github/workflows/deploy-rules.yml
@@ -41,6 +41,25 @@ jobs:
       - name: Show Firebase CLI version
         run: npx --yes firebase-tools@14.16.0 --version
 
+      - name: Compile Firestore security rules
+        if: steps.authpick.outputs.method == 'token'
+        run: |
+          npx --yes firebase-tools@14.16.0 deploy \
+            --only firestore:rules \
+            --project "$PROJECT_ID" \
+            --token "${FIREBASE_TOKEN}" \
+            --debug
+        env:
+          FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
+
+      - name: Compile Firestore security rules (SA auth)
+        if: steps.authpick.outputs.method == 'sa'
+        run: |
+          npx --yes firebase-tools@14.16.0 deploy \
+            --only firestore:rules \
+            --project "$PROJECT_ID" \
+            --debug
+
       - name: Deploy Firestore security rules
         if: steps.authpick.outputs.method == 'token'
         run: |

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,5 +1,20 @@
 rules_version = '2';
 service cloud.firestore {
+  // Returns a nested map or a default when missing or not a map.
+  function mapOr(m, k, d) {
+    return (k in m && m[k] is map) ? m[k] : d;
+  }
+
+  // Returns a value from a map or a default when the key is missing.
+  function getOr(m, k, d) {
+    return (k in m) ? m[k] : d;
+  }
+
+  // Checks for a two-level deep key like m[k1][k2].
+  function has2(m, k1, k2) {
+    return (k1 in m) && (m[k1] is map) && (k2 in m[k1]);
+  }
+
   match /databases/{database}/documents {
 
     function isAdmin() {
@@ -88,8 +103,10 @@ service cloud.firestore {
         function isCheck(tableId) {
           let seat = resource.data.toActSeat;
           let bet = resource.data.betToMatchCents;
-          let oldCommit = resource.data.commits[seat] ?? 0;
-          let newCommit = request.resource.data.commits[seat] ?? oldCommit;
+          let commits = mapOr(resource.data, 'commits', {});
+          let oldCommit = getOr(commits, seat, 0);
+          let reqCommits = mapOr(request.resource.data, 'commits', {});
+          let newCommit = getOr(reqCommits, seat, oldCommit);
           let delta = newCommit - oldCommit;
           return actorIs(tableId, seat) && bet == oldCommit && delta == 0 &&
                  request.resource.data.diff(resource.data).changedKeys()
@@ -101,8 +118,10 @@ service cloud.firestore {
         function isCall(tableId) {
           let seat = resource.data.toActSeat;
           let bet = resource.data.betToMatchCents;
-          let oldCommit = resource.data.commits[seat] ?? 0;
-          let newCommit = request.resource.data.commits[seat] ?? 0;
+          let commits = mapOr(resource.data, 'commits', {});
+          let oldCommit = getOr(commits, seat, 0);
+          let reqCommits = mapOr(request.resource.data, 'commits', {});
+          let newCommit = getOr(reqCommits, seat, 0);
           let delta = newCommit - oldCommit;
           return actorIs(tableId, seat) && delta == bet - oldCommit && delta >= 0 &&
                  request.resource.data.diff(resource.data).changedKeys()


### PR DESCRIPTION
## Summary
- replace optional chaining and nullish coalescing in Firestore rules using safe helpers
- add compile check step to Firestore rules deployment workflow

## Testing
- `npx --yes firebase-tools@14.16.0 deploy --only firestore:rules --project demo-project --token fake-token --debug` *(fails: 403 Forbidden when fetching firebase-tools)*

------
https://chatgpt.com/codex/tasks/task_e_68c66f9070c4832eb336f29363968129