### PR TITLE
feat: add server action processor for betting flow

### DIFF
--- a/functions/src/actionProcessor.ts
+++ b/functions/src/actionProcessor.ts
@@ -1,0 +1,186 @@
+import { onDocumentCreated } from "firebase-functions/v2/firestore";
+import { getFirestore, FieldValue } from "firebase-admin/firestore";
+
+const db = getFirestore();
+
+interface SeatData {
+  seat: number;
+  stackCents: number;
+}
+
+function orderedSeats(seats: SeatData[]): number[] {
+  return seats
+    .map((s) => s.seat)
+    .sort((a, b) => a - b);
+}
+
+function nextActiveLeft(
+  seats: SeatData[],
+  from: number,
+  folded: Set<number>
+): number | null {
+  const order = orderedSeats(seats);
+  const start = order.indexOf(from);
+  if (start === -1) return null;
+  for (let i = 1; i <= order.length; i++) {
+    const seatNum = order[(start + i) % order.length];
+    const data = seats.find((s) => s.seat === seatNum);
+    if (!data) continue;
+    if (folded.has(seatNum)) continue;
+    if (data.stackCents <= 0) continue;
+    return seatNum;
+  }
+  return null;
+}
+
+function firstActiveLeftOfDealer(
+  seats: SeatData[],
+  dealer: number,
+  folded: Set<number>
+): number | null {
+  const order = orderedSeats(seats);
+  const start = order.indexOf(dealer);
+  if (start === -1) return null;
+  for (let i = 1; i <= order.length; i++) {
+    const seatNum = order[(start + i) % order.length];
+    const data = seats.find((s) => s.seat === seatNum);
+    if (!data) continue;
+    if (folded.has(seatNum)) continue;
+    if (data.stackCents <= 0) continue;
+    return seatNum;
+  }
+  return null;
+}
+
+function everyoneMatched(
+  commits: Record<string, number>,
+  betToMatch: number,
+  seats: SeatData[],
+  folded: Set<number>
+): boolean {
+  for (const s of seats) {
+    if (folded.has(s.seat)) continue;
+    const c = commits?.[s.seat] ?? commits?.[String(s.seat)] ?? 0;
+    if (c !== betToMatch) return false;
+  }
+  return true;
+}
+
+function nextStreet(street: string): string {
+  switch (street) {
+    case "preflop":
+      return "flop";
+    case "flop":
+      return "turn";
+    case "turn":
+      return "river";
+    default:
+      return "showdown";
+  }
+}
+
+function advanceStreet(
+  hand: any,
+  seats: SeatData[],
+  folded: Set<number>
+) {
+  const street = nextStreet(hand.street);
+  const toAct = firstActiveLeftOfDealer(seats, hand.dealerSeat, folded);
+  return {
+    street,
+    betToMatchCents: 0,
+    commits: {},
+    lastAggressorSeat: -1,
+    minRaiseToCents: 0,
+    toActSeat: toAct,
+    updatedAt: FieldValue.serverTimestamp(),
+  };
+}
+
+export const onActionCreated = onDocumentCreated(
+  {
+    region: "us-central1",
+    document: "tables/{tableId}/actions/{actionId}",
+  },
+  async (event) => {
+    const { tableId } = event.params;
+    const action = event.data?.data() as any;
+    if (!action) return;
+
+    const tableRef = db.collection("tables").doc(tableId);
+    const handRef = tableRef.collection("handState").doc("current");
+    const seatRef = tableRef.collection("seats").doc(String(action.seat));
+
+    try {
+      await db.runTransaction(async (tx) => {
+        const [handSnap, seatSnap, seatsSnap] = await Promise.all([
+          tx.get(handRef),
+          tx.get(seatRef),
+          tx.get(tableRef.collection("seats")),
+        ]);
+        if (!handSnap.exists || !seatSnap.exists) return;
+        const hand = handSnap.data() as any;
+        const seat = seatSnap.data() as any;
+        const seats: SeatData[] = seatsSnap.docs.map((d) => ({
+          seat: d.data().seatIndex ?? parseInt(d.id, 10),
+          stackCents: d.data().stackCents ?? 0,
+        }));
+
+        const foldedSet = new Set<number>(hand.folded ?? []);
+        if (action.seat !== hand.toActSeat) return;
+        if (foldedSet.has(action.seat)) return;
+
+        const commits = hand.commits || {};
+        const playerCommit = commits?.[action.seat] ?? commits?.[String(action.seat)] ?? 0;
+        const betToMatch = hand.betToMatchCents || 0;
+
+        switch (action.type) {
+          case "check": {
+            if (betToMatch !== playerCommit) return;
+            if (everyoneMatched(commits, betToMatch, seats, foldedSet)) {
+              const adv = advanceStreet(hand, seats, foldedSet);
+              tx.update(handRef, adv);
+            } else {
+              const next = nextActiveLeft(seats, action.seat, foldedSet);
+              tx.update(handRef, {
+                toActSeat: next,
+                updatedAt: FieldValue.serverTimestamp(),
+              });
+            }
+            break;
+          }
+          case "call": {
+            const need = betToMatch - playerCommit;
+            if (need <= 0) return;
+            if (seat.stackCents < need) throw new Error("insufficient-stack");
+            const newStack = seat.stackCents - need;
+            const newCommit = playerCommit + need;
+            const commitPath = `commits.${action.seat}`;
+            if (everyoneMatched({ ...commits, [action.seat]: newCommit }, betToMatch, seats, foldedSet)) {
+              const adv = advanceStreet(hand, seats, foldedSet);
+              tx.update(handRef, { ...adv, [commitPath]: newCommit });
+            } else {
+              const next = nextActiveLeft(seats, action.seat, foldedSet);
+              tx.update(handRef, {
+                [commitPath]: newCommit,
+                toActSeat: next,
+                updatedAt: FieldValue.serverTimestamp(),
+              });
+            }
+            tx.update(seatRef, { stackCents: newStack });
+            break;
+          }
+          default:
+            return;
+        }
+      });
+      await event.data?.ref.update({ status: "applied" });
+    } catch (err: any) {
+      await event.data?.ref.update({
+        status: "error",
+        error: err?.message || String(err),
+      });
+    }
+  }
+);
+

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -719,3 +719,5 @@ export const onVariantChosen = onDocumentUpdated(
     });
   }
 );
+
+export { onActionCreated } from "./actionProcessor";

--- a/src/poker/tx/call.ts
+++ b/src/poker/tx/call.ts
@@ -1,24 +1,17 @@
-import { runTransaction, serverTimestamp } from 'firebase/firestore';
-import { computeToCall, HandState, maybeAdvanceStreet } from '../handMath';
+import { addDoc, collection, serverTimestamp } from 'firebase/firestore';
 
-export async function call(db: any, handRef: any): Promise<void> {
-  await runTransaction(db, async (tx: any) => {
-    const snap = await tx.get(handRef);
-    const hand = snap.data() as HandState;
-    if (!hand) throw new Error('missing-hand');
-    const seat = hand.toActSeat as number;
-    const toCall = computeToCall(hand, seat);
-    if (toCall <= 0) throw new Error('no-call');
-    const newCommit = (hand.commits?.[seat] ?? 0) + toCall;
-    const after: HandState = {
-      ...hand,
-      commits: { ...hand.commits, [seat]: newCommit },
-    };
-    const advance = maybeAdvanceStreet(after);
-    tx.update(handRef, {
-      [`commits.${seat}`]: newCommit,
-      ...advance,
-      updatedAt: serverTimestamp(),
-    });
+export async function call(
+  db: any,
+  tableId: string,
+  seat: number,
+  uid: string,
+  amountCents?: number
+): Promise<void> {
+  await addDoc(collection(db, `tables/${tableId}/actions`), {
+    seat,
+    type: 'call',
+    amountCents,
+    createdByUid: uid,
+    createdAt: serverTimestamp(),
   });
 }

--- a/src/poker/tx/check.ts
+++ b/src/poker/tx/check.ts
@@ -1,15 +1,15 @@
-import { runTransaction, serverTimestamp } from 'firebase/firestore';
-import { computeToCall, HandState, maybeAdvanceStreet } from '../handMath';
+import { addDoc, collection, serverTimestamp } from 'firebase/firestore';
 
-export async function check(db: any, handRef: any): Promise<void> {
-  await runTransaction(db, async (tx: any) => {
-    const snap = await tx.get(handRef);
-    const hand = snap.data() as HandState;
-    if (!hand) throw new Error('missing-hand');
-    const seat = hand.toActSeat;
-    const toCall = computeToCall(hand, seat ?? -1);
-    if (toCall > 0) throw new Error('now-must-call');
-    const advance = maybeAdvanceStreet(hand);
-    tx.update(handRef, { ...advance, updatedAt: serverTimestamp() });
+export async function check(
+  db: any,
+  tableId: string,
+  seat: number,
+  uid: string
+): Promise<void> {
+  await addDoc(collection(db, `tables/${tableId}/actions`), {
+    seat,
+    type: 'check',
+    createdByUid: uid,
+    createdAt: serverTimestamp(),
   });
 }


### PR DESCRIPTION
## Summary
- process queued table actions on the server and update turn and stacks
- enqueue check and call actions from the client

## Testing
- `npm --prefix functions run build`


------
https://chatgpt.com/codex/tasks/task_e_68c67633b700832e9941ee22444edbcf