### PR TITLE
ui: fix turn detection via seat coercion; add turn snapshot logs; disable start while active

### DIFF
--- a/functions/src/actionProcessor.ts
+++ b/functions/src/actionProcessor.ts
@@ -116,8 +116,12 @@ export const onActionCreated = onDocumentCreated(
           rejected = true;
           return;
         }
-        const hand = handSnap.data() as any;
-        const seat = seatSnap.data() as any;
+          const hand = handSnap.data() as any;
+          hand.toActSeat = toSeatNumber(hand?.toActSeat);
+          hand.sbSeat = toSeatNumber(hand?.sbSeat);
+          hand.bbSeat = toSeatNumber(hand?.bbSeat);
+          hand.dealerSeat = toSeatNumber(hand?.dealerSeat);
+          const seat = seatSnap.data() as any;
         const seats: SeatData[] = seatsSnap.docs.map((d) => ({
           seat: d.data().seatIndex ?? parseInt(d.id, 10),
           stackCents: d.data().stackCents ?? 0,

--- a/functions/src/lib/seats.ts
+++ b/functions/src/lib/seats.ts
@@ -1,10 +1,18 @@
-export function toSeatNumber(v: unknown): number | null {
+export const toSeatNumber = (v: unknown): number | null => {
   if (typeof v === 'number' && Number.isInteger(v)) return v;
   if (typeof v === 'string' && /^\d+$/.test(v)) return Number(v);
   return null;
-}
+};
 
-export function findMySeat(seats: any[], myUid: string): number | null {
-  const s = seats.find((x) => x?.uid === myUid);
-  return toSeatNumber((s as any)?.seat ?? (s as any)?.id ?? null);
-}
+export const findMySeat = (seats: Array<any>, myUid: string): number | null => {
+  // seat can be in seats[i].seat or the array index; support both
+  for (let i = 0; i < seats.length; i++) {
+    const s = seats[i];
+    if (!s) continue;
+    if (s.uid === myUid) {
+      const n = toSeatNumber((s as any).seat ?? i);
+      return n ?? null;
+    }
+  }
+  return null;
+};

--- a/public/table.html
+++ b/public/table.html
@@ -32,10 +32,16 @@
       writeBatch, runTransaction, increment, getDoc
     } from "https://www.gstatic.com/firebasejs/10.12.5/firebase-firestore.js";
     import { awaitAuthReady, auth } from "/auth.js";
-    import { handDocPath } from "/js/dbPaths.js";
-    import { logEvent } from "/js/debug.js";
+      import { handDocPath } from "/js/dbPaths.js";
+      import { logEvent } from "/js/debug.js";
 
-    const shortUid = (uid) => uid ? uid.slice(0, 6) : 'null';
+      const shortUid = (uid) => uid ? uid.slice(0, 6) : 'null';
+
+      const toSeatNumber = (v) => {
+        if (typeof v === 'number' && Number.isInteger(v)) return v;
+        if (typeof v === 'string' && /^\d+$/.test(v)) return Number(v);
+        return null;
+      };
 
     if (window.jamlog && isDebug()) {
       window.jamlog.init({ projectId: app.options.projectId, build: window.__BUILD_SHA__ || 'dev', page: 'TABLE' });
@@ -99,14 +105,18 @@
       errorEl.innerHTML = '<h1>Table not found</h1><a href="/lobby.html">Back to Lobby</a>';
     } else {
       if (window.jamlog) window.jamlog.push('hand.state.sub.start');
-      unsubHandState = subscribeHandState(tableId, (data) => {
-        if (data) {
-          handState = data;
-          noHandBanner.style.display = 'none';
-          renderSeats();
-          renderPlayerBoard();
-          if (window.jamlog) window.jamlog.push('hand.state.sub.ok', { handNo: handState?.handNo ?? 0 });
-        } else {
+        unsubHandState = subscribeHandState(tableId, (data) => {
+          if (data) {
+            handState = data;
+            handState.toActSeat = toSeatNumber(handState?.toActSeat);
+            handState.sbSeat = toSeatNumber(handState?.sbSeat);
+            handState.bbSeat = toSeatNumber(handState?.bbSeat);
+            handState.dealerSeat = toSeatNumber(handState?.dealerSeat);
+            noHandBanner.style.display = 'none';
+            renderSeats();
+            renderPlayerBoard();
+            if (window.jamlog) window.jamlog.push('hand.state.sub.ok', { handNo: handState?.handNo ?? 0 });
+          } else {
           handState = null;
           renderSeats();
           renderPlayerBoard();
@@ -152,15 +162,19 @@
         const seatsRef = collection(db, 'tables', tableId, 'seats');
         if (window.jamlog) window.jamlog.push('table.seats.sub.started');
         const qSeats = query(seatsRef, orderBy('seatIndex', 'asc'));
-        onSnapshot(qSeats, (snap) => {
-          debugLog('table.seatsSnapshot', snap.size);
-          if (window.jamlog) window.jamlog.push('table.seats.sub.ok', { count: snap.size });
-          seatData = snap.docs.map((d) => ({ id: d.id, ...d.data() }));
-          showSeatsDebug(tableId, snap.docs);
-          renderSeats();
-          renderHand();
-          renderTableInfo();
-          renderPlayerBoard();
+          onSnapshot(qSeats, (snap) => {
+            debugLog('table.seatsSnapshot', snap.size);
+            if (window.jamlog) window.jamlog.push('table.seats.sub.ok', { count: snap.size });
+            seatData = snap.docs.map((d) => {
+              const data = d.data();
+              const seatIndex = toSeatNumber(data?.seatIndex ?? d.id);
+              return { id: d.id, ...data, seatIndex };
+            });
+            showSeatsDebug(tableId, snap.docs);
+            renderSeats();
+            renderHand();
+            renderTableInfo();
+            renderPlayerBoard();
           updateDebug();
           checkSeatCount();
           if (snap.size === 0 && (tableData?.maxSeats || 0) > 0) {
@@ -265,31 +279,34 @@
         ${startBtnHtml}
       `;
       document.getElementById('btn-rules-probe')?.addEventListener('click', () => rulesProbe(tableId));
-      const startBtn = document.getElementById('btn-start-hand');
-      const hintEl = document.getElementById('start-hand-hint');
-      startBtn.disabled = true;
-      let enable = false;
-      await awaitAuthReady();
-      const uid = auth.currentUser?.uid || null;
+        const startBtn = document.getElementById('btn-start-hand');
+        const hintEl = document.getElementById('start-hand-hint');
+        startBtn.disabled = true;
+        let enable = false;
+        await awaitAuthReady();
+        const uid = auth.currentUser?.uid || null;
       if (!t.createdByUid || (uid && t.createdByUid === uid)) {
         if (derivedSeatCount >= 2) {
           enable = true;
         } else {
           startBtn.title = 'Need 2+ players';
         }
-      } else {
-        const msg = `Only the table owner can start a hand. Owner: ${shortUid(t.createdByUid)}`;
-        startBtn.title = msg;
-        hintEl.textContent = msg;
-        hintEl.style.display = '';
-        if (window.jamlog) window.jamlog.push('hand.start.disabled', { reason: 'not-admin' });
+        } else {
+          const msg = `Only the table owner can start a hand. Owner: ${shortUid(t.createdByUid)}`;
+          startBtn.title = msg;
+          hintEl.textContent = msg;
+          hintEl.style.display = '';
+          if (window.jamlog) window.jamlog.push('hand.start.disabled', { reason: 'not-admin' });
+        }
+        const handActive = !!handData && typeof handData.handNo === 'number' && handData.street;
+        startBtn.disabled = handActive || !enable;
+        if (!startBtn.disabled) {
+          startBtn.removeAttribute('title');
+          startBtn.addEventListener('click', startHand);
+        } else if (handActive) {
+          startBtn.title = 'Hand already in progress';
+        }
       }
-      startBtn.disabled = !enable;
-      if (enable) {
-        startBtn.removeAttribute('title');
-        startBtn.addEventListener('click', startHand);
-      }
-    }
 
     function renderHand() {
       if (!handData) {
@@ -569,40 +586,59 @@
     }
     function nextToAct(state, fromSeat){ return nextOccupiedAfter(fromSeat, { skipFolded:true }); }
 
-    function renderPlayerBoard() {
-      const current = getCurrentPlayer();
-      mySeatIndex = seatData.find(s => s.occupiedBy === current?.id)?.seatIndex ?? null;
-      const occupiedSeats = seatData.filter(s => s.occupiedBy).map(s => s.seatIndex);
-      if (!current || mySeatIndex == null) { boardEl.style.display = 'none'; return; }
-      boardEl.style.display = 'block';
-      boardEl.innerHTML = '<div style="display:flex; gap:8px; justify-content:center;"><button id="btn-check">Check</button><button id="btn-call">Call</button><button id="btn-fold">Fold</button></div><div style="display:flex; justify-content:center; margin-top:8px;"><button id="btn-leave-seat">Leave seat</button></div>';
-      const checkBtn = document.getElementById('btn-check');
-      const callBtn = document.getElementById('btn-call');
-      const foldBtn = document.getElementById('btn-fold');
-      const leaveBtn = document.getElementById('btn-leave-seat');
-      let reason = 'ok';
-      let enable = handState && handState.street === 'preflop' && handState.toActSeat === mySeatIndex && !foldedSeats.has(mySeatIndex);
-      if (!handState || handState.street !== 'preflop') { reason = 'no-hand'; enable = false; }
-      else if (handState.toActSeat !== mySeatIndex || foldedSeats.has(mySeatIndex)) { reason = 'not-your-turn'; enable = false; }
-      const tooltip = reason === 'no-hand' ? 'Start Hand first' : 'Waiting for your turn';
-      [checkBtn, callBtn, foldBtn].forEach(b => { b.disabled = !enable; if (!enable) b.title = tooltip; else b.removeAttribute('title'); });
-      if (window.jamlog) window.jamlog.push('action.guard', { reason });
-      leaveBtn.addEventListener('click', () => leaveSeat(mySeatIndex));
-      if (enable) {
-        const myCommit = commitOf(handState, mySeatIndex);
-        const target = handState.betToMatchCents || 0;
-        checkBtn.disabled = myCommit !== target;
-        callBtn.disabled = myCommit >= target;
-        if (handState.street === 'preflop' && mySeatIndex === handState.bbSeat && myCommit === target) {
-          checkBtn.style.fontWeight = '700';
-        } else {
-          checkBtn.style.fontWeight = '';
+      function renderPlayerBoard() {
+        const current = getCurrentPlayer();
+        mySeatIndex = seatData.find(s => s.occupiedBy === current?.id)?.seatIndex ?? null;
+        const occupiedSeats = seatData.filter(s => s.occupiedBy).map(s => s.seatIndex);
+        if (!current || mySeatIndex == null) { boardEl.style.display = 'none'; return; }
+        const myCommit = handState ? commitOf(handState, mySeatIndex) : 0;
+        const toMatch = handState?.betToMatchCents ?? 0;
+        const owe = Math.max(0, toMatch - myCommit);
+        if (window.jamlog) window.jamlog.push('turn.snapshot', {
+          myUid: current?.id || null,
+          mySeat: mySeatIndex,
+          toActSeat: toSeatNumber(handState?.toActSeat),
+          seats: seatData.map((s, i) => ({ i, seat: toSeatNumber(s?.seatIndex ?? i), uid: s?.occupiedBy || null })),
+          street: handState?.street || null,
+          handNo: handState?.handNo || null,
+        });
+        boardEl.style.display = 'block';
+        boardEl.innerHTML = '<div style="display:flex; gap:8px; justify-content:center;"><button id="btn-check">Check</button><button id="btn-call">Call</button><button id="btn-fold">Fold</button></div><div style="display:flex; justify-content:center; margin-top:8px;"><button id="btn-leave-seat">Leave seat</button></div>';
+        const checkBtn = document.getElementById('btn-check');
+        const callBtn = document.getElementById('btn-call');
+        const foldBtn = document.getElementById('btn-fold');
+        const leaveBtn = document.getElementById('btn-leave-seat');
+        let reason = 'ok';
+        let enable = handState && handState.street === 'preflop' && handState.toActSeat === mySeatIndex && !foldedSeats.has(mySeatIndex);
+        if (!handState || handState.street !== 'preflop') { reason = 'no-hand'; enable = false; }
+        else if (handState.toActSeat !== mySeatIndex || foldedSeats.has(mySeatIndex)) { reason = 'not-your-turn'; enable = false; }
+        const tooltip = reason === 'no-hand' ? 'Start Hand first' : 'Waiting for your turn';
+        [checkBtn, callBtn, foldBtn].forEach(b => { b.disabled = !enable; if (!enable) b.title = tooltip; else b.removeAttribute('title'); });
+        if (window.jamlog) window.jamlog.push('action.guard', {
+          reason,
+          myUid: current?.id || null,
+          mySeat: mySeatIndex,
+          toActSeat: handState?.toActSeat ?? null,
+          toMatch,
+          myCommit,
+          owe,
+          street: handState?.street,
+        });
+        leaveBtn.addEventListener('click', () => leaveSeat(mySeatIndex));
+        if (enable) {
+          const target = toMatch;
+          checkBtn.disabled = myCommit !== target;
+          callBtn.disabled = myCommit >= target;
+          if (handState.street === 'preflop' && mySeatIndex === handState.bbSeat && myCommit === target) {
+            checkBtn.style.fontWeight = '700';
+          } else {
+            checkBtn.style.fontWeight = '';
+          }
+          checkBtn.addEventListener('click', () => handleCheck(occupiedSeats));
+          callBtn.addEventListener('click', () => handleCall());
+          foldBtn.addEventListener('click', () => handleFold());
         }
-        checkBtn.addEventListener('click', () => handleCheck(occupiedSeats));
-        callBtn.addEventListener('click', () => handleCall());
-        foldBtn.addEventListener('click', () => handleFold());
       }
-    }
 
     async function handleCheck(occupiedSeats) {
       if (handState?.toActSeat !== mySeatIndex) {

--- a/src/lib/seats.ts
+++ b/src/lib/seats.ts
@@ -1,10 +1,18 @@
-export function toSeatNumber(v: unknown): number | null {
+export const toSeatNumber = (v: unknown): number | null => {
   if (typeof v === 'number' && Number.isInteger(v)) return v;
   if (typeof v === 'string' && /^\d+$/.test(v)) return Number(v);
   return null;
-}
+};
 
-export function findMySeat(seats: any[], myUid: string): number | null {
-  const s = seats.find((x) => x?.uid === myUid);
-  return toSeatNumber((s as any)?.seat ?? (s as any)?.id ?? null);
-}
+export const findMySeat = (seats: Array<any>, myUid: string): number | null => {
+  // seat can be in seats[i].seat or the array index; support both
+  for (let i = 0; i < seats.length; i++) {
+    const s = seats[i];
+    if (!s) continue;
+    if (s.uid === myUid) {
+      const n = toSeatNumber((s as any).seat ?? i);
+      return n ?? null;
+    }
+  }
+  return null;
+};

--- a/src/lib/turn.ts
+++ b/src/lib/turn.ts
@@ -1,19 +1,14 @@
-type HandState = {
-  toActSeat: unknown;
-  betToMatchCents?: unknown;
-  commits?: Record<string, unknown>;
-  folded?: unknown[];
-  street?: string;
-};
+import { toSeatNumber } from './seats';
 
-export function computeTurn(hand: HandState | null, mySeat: number | null, myStackCents: number) {
-  if (!hand || mySeat == null) return { ready: false } as const;
+export function computeTurn(hand: any, mySeatRaw: unknown, myStackCents: number) {
+  const mySeat = toSeatNumber(mySeatRaw);
+  const toActSeat = toSeatNumber(hand?.toActSeat);
+  if (hand == null || mySeat == null || toActSeat == null) return { ready: false } as const;
 
-  const toActSeat = Number((hand as any).toActSeat ?? -1);
-  const folded = new Set((hand?.folded ?? []).map((n: any) => Number(n)));
-  const commits = hand?.commits ?? {};
+  const folded = new Set((hand.folded ?? []).map((x: any) => Number(x)));
+  const commits = hand.commits ?? {};
   const myCommit = Number(commits[String(mySeat)] ?? 0);
-  const toMatch = Number((hand as any).betToMatchCents ?? 0);
+  const toMatch = Number(hand.betToMatchCents ?? 0);
   const owe = Math.max(0, toMatch - myCommit);
 
   const canAct = toActSeat === mySeat && !folded.has(mySeat);
@@ -22,5 +17,17 @@ export function computeTurn(hand: HandState | null, mySeat: number | null, mySta
   const canBet = canAct && toMatch === 0 && myStackCents > 0;
   const canFold = canAct;
 
-  return { ready: true, toActSeat, toMatch, myCommit, owe, canAct, canCheck, canCall, canBet, canFold } as const;
+  return {
+    ready: true,
+    mySeat,
+    toActSeat,
+    toMatch,
+    myCommit,
+    owe,
+    canAct,
+    canCheck,
+    canCall,
+    canBet,
+    canFold,
+  } as const;
 }

--- a/src/ui/TableActions.tsx
+++ b/src/ui/TableActions.tsx
@@ -50,6 +50,21 @@ export const TableActions: React.FC<TableActionsProps> = ({
   }, [turn.canAct, turn.canCheck, turn.canCall, turn.canBet, turn.canFold]);
 
   useEffect(() => {
+    telemetry('turn.snapshot', {
+      myUid: uid,
+      mySeat,
+      toActSeat: toSeatNumber(handState?.toActSeat),
+      seats: (seats ?? []).map((s: any, i: number) => ({
+        i,
+        seat: toSeatNumber((s as any)?.seat ?? i),
+        uid: (s as any)?.uid,
+      })),
+      street: handState?.street,
+      handNo: (handState as any)?.handNo,
+    });
+  }, [uid, mySeat, handState?.toActSeat, handState?.street, (handState as any)?.handNo, seats]);
+
+  useEffect(() => {
     if (!pending) return;
     const updated: any = handState && (handState as any).updatedAt;
     if (updated?.toMillis && updated.toMillis() > lastActionAtRef.current) {


### PR DESCRIPTION
## Summary
- normalize seat identifiers and expose helper to locate current player
- compute turn state from coerced seats and log turn snapshots
- guard action processing with seat coercion and disable Start Hand during active hand

## Testing
- `npm test` *(fails: ENOENT package.json)*
- `cd functions && npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68c68177208c832e89813d1cc3417a61