### PR TITLE
Refactor turn handling to rely solely on live snapshot

### DIFF
--- a/functions/src/actionProcessor.ts
+++ b/functions/src/actionProcessor.ts
@@ -156,12 +156,14 @@ export const onActionCreated = onDocumentCreated(
         switch (action.type) {
           case "check": {
             if (betToMatch !== playerCommit) return;
+            const commitPath = `commits.${actorSeat}`;
             if (everyoneMatched(commits, betToMatch, seats, foldedSet)) {
               const adv = advanceStreet(hand, seats);
-              tx.update(handRef, adv);
+              tx.update(handRef, { ...adv, [commitPath]: playerCommit });
             } else {
               const next = nextEligible(actorSeat, seats, hand);
               tx.update(handRef, {
+                [commitPath]: playerCommit,
                 toActSeat: next,
                 updatedAt: FieldValue.serverTimestamp(),
               });

--- a/src/lib/turn.ts
+++ b/src/lib/turn.ts
@@ -1,24 +1,36 @@
 import { toSeatNumber } from './seats';
 
-export function computeTurn(hand: any, mySeatRaw: unknown, myStackCents: number) {
-  const mySeat = toSeatNumber(mySeatRaw);
-  const toActSeat = toSeatNumber(hand?.toActSeat);
-  if (hand == null || mySeat == null || toActSeat == null) return { ready: false } as const;
+interface Seat {
+  uid?: string;
+  stackCents?: number;
+  [k: string]: any;
+}
 
-  const folded = new Set((hand.folded ?? []).map((x: any) => Number(x)));
-  const commits = hand.commits ?? {};
+export function computeTurnFromDoc(
+  handDoc: any,
+  seats: Seat[],
+  myUid: string
+) {
+  const mySeat = seats.findIndex((s) => s?.uid === myUid);
+  const toActSeat = toSeatNumber(handDoc?.toActSeat);
+  if (!handDoc || mySeat < 0 || toActSeat == null) return { ready: false } as const;
+
+  const folded = new Set((handDoc.folded ?? []).map((x: any) => Number(x)));
+  const commits = handDoc.commits ?? {};
   const myCommit = Number(commits[String(mySeat)] ?? 0);
-  const toMatch = Number(hand.betToMatchCents ?? 0);
+  const toMatch = Number(handDoc.betToMatchCents ?? 0);
   const owe = Math.max(0, toMatch - myCommit);
+  const myStack = Number(seats[mySeat]?.stackCents ?? 0);
 
   const canAct = toActSeat === mySeat && !folded.has(mySeat);
   const canCheck = canAct && owe === 0;
-  const canCall = canAct && owe > 0 && myStackCents >= owe;
-  const canBet = canAct && toMatch === 0 && myStackCents > 0;
+  const canCall = canAct && owe > 0 && myStack >= owe;
+  const canBet = canAct && toMatch === 0 && myStack > 0;
   const canFold = canAct;
 
   return {
     ready: true,
+    myUid,
     mySeat,
     toActSeat,
     toMatch,
@@ -31,3 +43,21 @@ export function computeTurn(hand: any, mySeatRaw: unknown, myStackCents: number)
     canFold,
   } as const;
 }
+
+export function computeWhatIfTurn(
+  live: ReturnType<typeof computeTurnFromDoc>,
+  kind: 'check' | 'call' | 'raise',
+  amountCents?: number
+) {
+  const add =
+    kind === 'call'
+      ? live.owe
+      : kind === 'raise'
+      ? Number(amountCents || 0)
+      : 0;
+  const myCommit = live.myCommit + add;
+  const toMatch = kind === 'raise' ? live.toMatch + add : live.toMatch;
+  const owe = Math.max(0, toMatch - myCommit);
+  return { ...live, myCommit, toMatch, owe } as typeof live;
+}
+


### PR DESCRIPTION
## Summary
- Split live turn calculation from what-if preview
- Use live turn snapshot for guard logic in TableActions
- Ensure server transaction updates hand state even on check with zero delta

## Testing
- ❌ `npm test` (package.json not found)
- ✅ `npm --prefix functions run build`


------
https://chatgpt.com/codex/tasks/task_e_68c689d03508832ea88cf748983fc815