### PR TITLE
Fix Firebase admin init and action/payout bugs

### DIFF
--- a/functions/src/actionProcessor.ts
+++ b/functions/src/actionProcessor.ts
@@ -1,8 +1,7 @@
 import { onDocumentCreated } from "firebase-functions/v2/firestore";
-import { getFirestore, FieldValue } from "firebase-admin/firestore";
+import { FieldValue } from "firebase-admin/firestore";
 import { toSeatNumber } from "./lib/seats";
-
-const db = getFirestore();
+import { db } from "./admin";
 
 interface SeatData {
   seat: number;

--- a/functions/src/admin.ts
+++ b/functions/src/admin.ts
@@ -1,0 +1,5 @@
+import { getApps, getApp, initializeApp } from 'firebase-admin/app';
+import { getFirestore } from 'firebase-admin/firestore';
+
+const app = getApps().length ? getApp() : initializeApp();
+export const db = getFirestore(app);

--- a/functions/src/handEnd.ts
+++ b/functions/src/handEnd.ts
@@ -1,0 +1,39 @@
+import { onDocumentUpdated } from 'firebase-functions/v2/firestore';
+import { db } from './admin';
+
+export const onHandEndCleanup = onDocumentUpdated(
+  { region: 'us-central1', document: 'tables/{tableId}/handState/current' },
+  async (event) => {
+    const before = event.data?.before.data();
+    const after = event.data?.after.data();
+    if (!before || !after) return;
+    if (before.street === 'showdown' || after.street !== 'showdown') return;
+
+    const tableId = event.params.tableId;
+    const tableRef = db.doc(`tables/${tableId}`);
+
+    await db.runTransaction(async (tx) => {
+      const tableSnap = await tx.get(tableRef);
+      if (!tableSnap.exists) return;
+      const table = tableSnap.data() as any;
+      const seats: any[] = table.seats || [];
+      const leaving = seats
+        .map((s, i) => ({ ...s, seat: i }))
+        .filter((s) => s?.leaving && s.uid);
+      if (leaving.length === 0) return;
+
+      const userRefs = leaving.map((s) => db.doc(`users/${s.uid}`));
+      const userSnaps = await Promise.all(userRefs.map((r) => tx.get(r)));
+
+      leaving.forEach((s, idx) => {
+        const data = userSnaps[idx].data() || {};
+        const bank = (data.bankCents ?? 0) + (s.stackCents ?? 0);
+        tx.update(userRefs[idx], { bankCents: bank });
+        seats[s.seat] = { seat: s.seat, uid: null, stackCents: 0 };
+      });
+
+      const activeSeatCount = seats.filter((s) => s?.uid).length;
+      tx.update(tableRef, { seats, activeSeatCount });
+    });
+  }
+);

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -1,14 +1,13 @@
 // Cloud Functions: auto-start hands, dealer rotation, next-dealer variant
-import { initializeApp } from "firebase-admin/app";
-import { getFirestore, FieldValue, DocumentReference, Transaction, CollectionReference } from "firebase-admin/firestore";
+import { FieldValue, DocumentReference, Transaction, CollectionReference } from "firebase-admin/firestore";
+import { db } from "./admin";
 import { onRequest } from "firebase-functions/v2/https";
 import { onDocumentWritten, onDocumentUpdated, onDocumentCreated } from "firebase-functions/v2/firestore";
 
 export { takeActionTX } from "./takeActionTX";
 export { leaveSeatTX } from "./leaveSeatTX";
+export { onHandEndCleanup } from "./handEnd";
 
-initializeApp();
-const db = getFirestore();
 
 function getTableBlinds(table: any) {
   return {

--- a/functions/src/takeActionTX.ts
+++ b/functions/src/takeActionTX.ts
@@ -1,9 +1,8 @@
 import { onCall, HttpsError, CallableRequest } from 'firebase-functions/v2/https';
-import { getFirestore, FieldValue } from 'firebase-admin/firestore';
+import { FieldValue } from 'firebase-admin/firestore';
+import { db } from './admin';
 
-const db = getFirestore();
-
-function nextLiveSeat(seats: any[], hand: any, start: number): number {
+function nextActiveSeat(seats: any[], hand: any, start: number): number {
   const total = seats.length;
   const folded = new Set((hand?.folded ?? []).map((n: any) => Number(n)));
   for (let i = 1; i <= total; i++) {
@@ -12,6 +11,50 @@ function nextLiveSeat(seats: any[], hand: any, start: number): number {
     if (seat?.uid && !folded.has(idx)) return idx;
   }
   return start;
+}
+
+function activeSeats(seats: any[], hand: any): number[] {
+  const folded = new Set((hand?.folded ?? []).map((n: any) => Number(n)));
+  return seats
+    .map((s: any, i: number) => (s?.uid && !folded.has(i) ? i : -1))
+    .filter((i: number) => i >= 0);
+}
+
+function sumCommits(commits: Record<string, number>): number {
+  return Object.values(commits || {}).reduce((m, v) => m + Number(v || 0), 0);
+}
+
+function streetStarter(seats: any[], hand: any): number {
+  if (hand.street === 'preflop') {
+    const bb = typeof hand.bbSeat === 'number' ? hand.bbSeat : hand.dealerSeat;
+    return nextActiveSeat(seats, hand, bb);
+  }
+  return nextActiveSeat(seats, hand, hand.dealerSeat ?? 0);
+}
+
+function nextStreet(street: string): string {
+  switch (street) {
+    case 'preflop':
+      return 'flop';
+    case 'flop':
+      return 'turn';
+    case 'turn':
+      return 'river';
+    default:
+      return 'showdown';
+  }
+}
+
+function advanceStreet(hand: any, seats: any[]) {
+  const street = nextStreet(hand.street);
+  const toAct = street === 'showdown' ? null : streetStarter(seats, hand);
+  return {
+    street,
+    betToMatchCents: 0,
+    lastAggressorSeat: null,
+    toActSeat: toAct,
+    updatedAt: FieldValue.serverTimestamp(),
+  };
 }
 
 export const takeActionTX = onCall(async (request: CallableRequest<any>) => {
@@ -45,20 +88,40 @@ export const takeActionTX = onCall(async (request: CallableRequest<any>) => {
     const toMatch = hand.betToMatchCents ?? 0;
     const owe = Math.max(0, toMatch - myCommit);
 
-    let add = 0;
-    if (kind === 'call') add = owe;
-    else if (kind === 'check') add = 0;
-    else throw new HttpsError('invalid-argument', 'bad-kind');
+    const startSeat = streetStarter(table.seats, hand);
+    const nextSeat = nextActiveSeat(table.seats, hand, mySeat);
+    const actives = activeSeats(table.seats, hand);
 
-    commits[key] = myCommit + add;
-    const nextSeat = nextLiveSeat(table.seats, hand, mySeat);
+    let updates: any = { updatedAt: FieldValue.serverTimestamp() };
 
-    tx.update(handRef, {
-      commits,
-      toActSeat: nextSeat,
-      lastAggressorSeat: kind === 'raise' ? mySeat : hand.lastAggressorSeat ?? null,
-      updatedAt: FieldValue.serverTimestamp(),
-    });
+    if (kind === 'call') {
+      if (owe <= 0 || mySeat !== hand.toActSeat) {
+        throw new HttpsError('failed-precondition', 'cannot-call');
+      }
+      commits[key] = myCommit + owe;
+      updates.commits = commits;
+      updates.potCents = sumCommits(commits);
+      const allMatched = actives.every((s) => (commits[String(s)] ?? 0) >= toMatch);
+      if (allMatched && nextSeat === startSeat) {
+        updates = { ...updates, ...advanceStreet(hand, table.seats) };
+      } else {
+        updates.toActSeat = nextSeat;
+      }
+    } else if (kind === 'check') {
+      if (owe > 0 || mySeat !== hand.toActSeat) {
+        throw new HttpsError('failed-precondition', 'cannot-check');
+      }
+      updates.potCents = sumCommits(commits);
+      if (nextSeat === startSeat) {
+        updates = { ...updates, ...advanceStreet(hand, table.seats) };
+      } else {
+        updates.toActSeat = nextSeat;
+      }
+    } else {
+      throw new HttpsError('invalid-argument', 'bad-kind');
+    }
+
+    tx.update(handRef, updates);
   });
 });
 

--- a/src/lib/turn.ts
+++ b/src/lib/turn.ts
@@ -16,6 +16,10 @@ export function computeLiveTurn(
   const commits = handDoc?.commits ?? {};
   const myCommit = commits[String(mySeat)] ?? 0;
   const toMatch = handDoc?.betToMatchCents ?? 0;
+  const potCents = Object.values(commits).reduce(
+    (sum: number, v: any) => sum + Number(v || 0),
+    0
+  );
   return {
     myUid: authUid,
     mySeat,
@@ -25,6 +29,7 @@ export function computeLiveTurn(
     toMatch,
     myCommit,
     owe: Math.max(0, toMatch - myCommit),
+    potCents,
   };
 }
 

--- a/src/ui/TableActions.tsx
+++ b/src/ui/TableActions.tsx
@@ -99,6 +99,7 @@ export const TableActions: React.FC<TableActionsProps> = ({
   const label = canCheck
     ? 'Check'
     : `Call $${(turn.owe / 100).toFixed(2)}`;
+  const potLabel = `$${(turn.potCents / 100).toFixed(2)}`;
 
   const handlePrimary = async () => {
     const handNow = handRef.current;
@@ -207,6 +208,7 @@ export const TableActions: React.FC<TableActionsProps> = ({
 
   return (
     <div>
+      <div>Pot: {potLabel}</div>
       <button
         disabled={!canAct || (!canCheck && !canCall) || pending}
         onClick={handlePrimary}


### PR DESCRIPTION
## Summary
- Centralize Firebase Admin initialization to prevent deploy crashes
- Correct CALL/CHECK logic to advance streets and update pot
- Return chips to player banks when leaving, including post-hand cleanup
- Show table pot based on commit totals

## Testing
- `npm --prefix functions run build`


------
https://chatgpt.com/codex/tasks/task_e_68c68fc0b5e8832e8772b0659da44997