### PR TITLE
Lock hand state to server; transactional CALL; remove client writes; add version guard

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -1,34 +1,14 @@
 rules_version = '2';
 service cloud.firestore {
-  // Returns a nested map or a default when missing or not a map.
-  function mapOr(m, k, d) {
-    return (k in m && m[k] is map) ? m[k] : d;
-  }
-
-  // Returns a value from a map or a default when the key is missing.
-  function getOr(m, k, d) {
-    return (k in m) ? m[k] : d;
-  }
-
-  // Checks for a two-level deep key like m[k1][k2].
-  function has2(m, k1, k2) {
-    return (k1 in m) && (m[k1] is map) && (k2 in m[k1]);
-  }
-
   match /databases/{database}/documents {
+    function authed() {
+      return request.auth != null;
+    }
 
     function isAdmin() {
       return request.auth != null && request.auth.token.admin == true;
     }
 
-    function tableDoc(tableId) {
-      return get(/databases/$(database)/documents/tables/$(tableId));
-    }
-    function isTableAdmin(tableId) {
-      return request.auth != null &&
-             tableDoc(tableId).data.createdByUid != null &&
-             tableDoc(tableId).data.createdByUid == request.auth.uid;
-    }
 
     // Helpers for key shape validation
     function onlyAllowedKeys(allowed) {
@@ -85,53 +65,8 @@ service cloud.firestore {
 
       // Canonical hand state path:
       match /handState/{docId} {
-        allow read: if true;
-
-        function streetToNum(s) {
-          return s == 'preflop' ? 0
-               : s == 'flop' ? 1
-               : s == 'turn' ? 2
-               : 3;
-        }
-
-        function actorIs(tableId, seat) {
-          return request.auth != null &&
-                 get(/databases/$(database)/documents/tables/$(tableId)/seats/$(seat))
-                   .data.occupiedBy == request.auth.uid;
-        }
-
-        function isCheck(tableId) {
-          let seat = resource.data.toActSeat;
-          let bet = resource.data.betToMatchCents;
-          let commits = mapOr(resource.data, 'commits', {});
-          let oldCommit = getOr(commits, seat, 0);
-          let reqCommits = mapOr(request.resource.data, 'commits', {});
-          let newCommit = getOr(reqCommits, seat, oldCommit);
-          let delta = newCommit - oldCommit;
-          return actorIs(tableId, seat) && bet == oldCommit && delta == 0 &&
-                 request.resource.data.diff(resource.data).changedKeys()
-                   .hasOnly(['toActSeat','updatedAt','street','lastAggressorSeat','betToMatchCents']) &&
-                 streetToNum(request.resource.data.street) >= streetToNum(resource.data.street) &&
-                 request.resource.data.toActSeat != resource.data.toActSeat;
-        }
-
-        function isCall(tableId) {
-          let seat = resource.data.toActSeat;
-          let bet = resource.data.betToMatchCents;
-          let commits = mapOr(resource.data, 'commits', {});
-          let oldCommit = getOr(commits, seat, 0);
-          let reqCommits = mapOr(request.resource.data, 'commits', {});
-          let newCommit = getOr(reqCommits, seat, 0);
-          let delta = newCommit - oldCommit;
-          return actorIs(tableId, seat) && delta == bet - oldCommit && delta >= 0 &&
-                 request.resource.data.diff(resource.data).changedKeys()
-                   .hasOnly(['toActSeat','updatedAt','commits','street','lastAggressorSeat','betToMatchCents']) &&
-                 streetToNum(request.resource.data.street) >= streetToNum(resource.data.street) &&
-                 request.resource.data.toActSeat != resource.data.toActSeat;
-        }
-
-        allow update: if isCheck(tableId) || isCall(tableId);
-        allow create, delete: if isTableAdmin(tableId);
+        allow read: if authed();
+        allow write: if false;
       }
     }
 

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -7,6 +7,7 @@ import { onDocumentWritten, onDocumentUpdated, onDocumentCreated } from "firebas
 export { takeActionTX } from "./takeActionTX";
 export { leaveSeatTX } from "./leaveSeatTX";
 export { onHandEndCleanup } from "./handEnd";
+export { pokerCall } from "./pokerCall";
 
 
 function getTableBlinds(table: any) {

--- a/functions/src/pokerCall.ts
+++ b/functions/src/pokerCall.ts
@@ -1,0 +1,62 @@
+import * as admin from 'firebase-admin';
+import { onCall, HttpsError } from 'firebase-functions/v2/https';
+import { logger } from 'firebase-functions';
+
+const db = admin.firestore();
+
+export const pokerCall = onCall({ cors: true }, async (req) => {
+  const { tableId } = req.data ?? {};
+  const uid = req.auth?.uid;
+  if (!uid) throw new HttpsError('unauthenticated', 'sign in');
+  if (!tableId) throw new HttpsError('invalid-argument', 'tableId required');
+
+  await db.runTransaction(async (tx) => {
+    const ref = db.doc(`tables/${tableId}/handState/current`);
+    const snap = await tx.get(ref);
+    if (!snap.exists) throw new HttpsError('failed-precondition', 'no-hand');
+    const s = snap.data() as any;
+
+    if (s.toActSeat !== s.sbSeat) {
+      throw new HttpsError('failed-precondition', 'not-your-turn');
+    }
+
+    const betToMatch = s.betToMatchCents ?? 0;
+    const commits = { ...(s.commits ?? {}) } as Record<string, number>;
+    const key = String(s.sbSeat);
+    const current = commits[key] ?? 0;
+    const delta = Math.max(0, betToMatch - current);
+    if (delta === 0) {
+      return;
+    }
+    commits[key] = betToMatch;
+
+    tx.update(ref, {
+      commits,
+      toActSeat: s.bbSeat,
+      lastAggressorSeat: s.bbSeat,
+      version: admin.firestore.FieldValue.increment(1),
+      updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+      lastWriteBy: 'cf:pokerCall',
+    });
+
+    const auditRef = db.collection(`tables/${tableId}/audits`).doc();
+    tx.set(auditRef, {
+      at: admin.firestore.FieldValue.serverTimestamp(),
+      by: uid,
+      action: 'call',
+      delta,
+      fromCommit: current,
+      toCommit: betToMatch,
+      tableId,
+    });
+
+    logger.info('pokerCall.write', {
+      tableId,
+      fields: ['commits', 'toActSeat'],
+      tag: 'cf',
+    });
+  });
+
+  return { ok: true };
+});
+

--- a/src/actions/call.ts
+++ b/src/actions/call.ts
@@ -1,0 +1,7 @@
+import { getFunctions, httpsCallable } from 'firebase/functions';
+
+const callCF = httpsCallable<{ tableId: string }, any>(getFunctions(), 'pokerCall');
+
+export async function call(tableId: string): Promise<void> {
+  await callCF({ tableId });
+}

--- a/src/state/handSubscriber.ts
+++ b/src/state/handSubscriber.ts
@@ -1,0 +1,15 @@
+import { DocumentReference, onSnapshot } from 'firebase/firestore';
+
+export function subscribeHand(
+  ref: DocumentReference,
+  cb: (data: any) => void
+) {
+  let lastVersion = -1;
+  return onSnapshot(ref, (snap) => {
+    const data = snap.data();
+    const version = typeof data?.version === 'number' ? data.version : 0;
+    if (version < lastVersion) return;
+    lastVersion = version;
+    cb(data);
+  });
+}

--- a/src/ui/TableActions.tsx
+++ b/src/ui/TableActions.tsx
@@ -38,7 +38,9 @@ export const TableActions: React.FC<TableActionsProps> = ({
     uid
   );
   const myStack = turn.mySeat >= 0 ? Number((seats as any[])[turn.mySeat]?.stackCents ?? 0) : 0;
-  const canAct = turn.toActSeat === turn.mySeat;
+  const seatMatchesUid = turn.mySeat >= 0 && (seats as any[])[turn.mySeat]?.uid === uid;
+  const canAct =
+    seatMatchesUid && turn.toActSeat === turn.mySeat && turn.street !== null;
   const canCheck = canAct && turn.owe === 0;
   const canCall = canAct && turn.owe > 0 && myStack >= turn.owe;
   const canFold = canAct;


### PR DESCRIPTION
## Summary
- deny client writes to `handState/current` and limit reads to authenticated users
- add transactional `pokerCall` Cloud Function with audit logging and version bump
- route client Call action through callable function and ignore stale snapshots

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npm test` (functions) *(fails: Missing script: "test")*
- `npm run build` (functions)


------
https://chatgpt.com/codex/tasks/task_e_68c6f7beed44832eaf10d5b07d663244