### PR TITLE
feat: start hand via cloud function

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -8,6 +8,7 @@ export { takeActionTX } from "./takeActionTX";
 export { leaveSeatTX } from "./leaveSeatTX";
 export { onHandEndCleanup } from "./handEnd";
 export { pokerCall } from "./pokerCall";
+export { startHand } from "./startHand";
 
 
 function getTableBlinds(table: any) {

--- a/functions/src/startHand.ts
+++ b/functions/src/startHand.ts
@@ -1,0 +1,79 @@
+import { onCall, HttpsError } from 'firebase-functions/v2/https';
+import { FieldValue } from 'firebase-admin/firestore';
+import { db } from './admin';
+
+export const startHand = onCall(async (request) => {
+  const { tableId } = request.data || {};
+  const uid = request.auth?.uid;
+  if (!uid) throw new HttpsError('unauthenticated', 'auth-required');
+  if (!tableId) throw new HttpsError('invalid-argument', 'missing-table');
+
+  const tableRef = db.doc(`tables/${tableId}`);
+  const handRef = db.doc(`tables/${tableId}/handState/current`);
+  const seatsCol = tableRef.collection('seats');
+
+  const result = await db.runTransaction(async (tx) => {
+    const [handSnap, seatsSnap, tableSnap] = await Promise.all([
+      tx.get(handRef),
+      tx.get(seatsCol),
+      tx.get(tableRef),
+    ]);
+
+    const hand = handSnap.data() as any;
+    if (hand?.street) {
+      // Hand already started; idempotent return
+      return { ok: true };
+    }
+
+    const occupied: number[] = [];
+    seatsSnap.forEach((d) => {
+      const data = d.data();
+      if (data?.occupiedBy) occupied.push(data.seatIndex);
+    });
+    occupied.sort((a, b) => a - b);
+
+    if (occupied.length < 2) {
+      return { ok: false, reason: 'not-enough-players' };
+    }
+
+    const next = (arr: number[], val: number) => arr[(arr.indexOf(val) + 1) % arr.length];
+    let dealer: number;
+    if (hand && occupied.includes(hand.dealerSeat)) dealer = next(occupied, hand.dealerSeat);
+    else dealer = occupied[0];
+    const sbSeat = next(occupied, dealer);
+    const bbSeat = next(occupied, sbSeat);
+    const toActSeat = next(occupied, bbSeat);
+    const handNo = (typeof hand?.handNo === 'number' ? hand.handNo : 0) + 1;
+
+    const table = tableSnap.data() as any || {};
+    const sb = table?.blinds?.sbCents || 0;
+    const bb = table?.blinds?.bbCents || 0;
+    const commits: Record<string, number> = {};
+    commits[String(sbSeat)] = sb;
+    commits[String(bbSeat)] = bb;
+
+    tx.set(handRef, {
+      handNo,
+      dealerSeat: dealer,
+      sbSeat,
+      bbSeat,
+      toActSeat,
+      street: 'preflop',
+      betToMatchCents: bb,
+      commits,
+      lastAggressorSeat: bbSeat,
+      updatedAt: FieldValue.serverTimestamp(),
+      version: FieldValue.increment(1),
+      lastWriteBy: 'cf:startHand',
+    }, { merge: true });
+
+    return { ok: true };
+  });
+
+  if (!result.ok) {
+    throw new HttpsError('failed-precondition', result.reason || '');
+  }
+
+  return { ok: true };
+});
+

--- a/public/admin.html
+++ b/public/admin.html
@@ -192,6 +192,7 @@
     import { awaitAuthReady, isAuthed } from "/auth.js";
     import { handDocPath } from "/js/dbPaths.js";
     import { logEvent } from "/js/debug.js";
+    import { getFunctions, httpsCallable } from "https://www.gstatic.com/firebasejs/10.12.5/firebase-functions.js";
 
     if (window.jamlog && isDebug()) {
       window.jamlog.init({ projectId: app.options.projectId, build: window.__BUILD_SHA__ || 'dev', page: 'ADMIN' });
@@ -202,6 +203,7 @@
 
     const authBanner = document.getElementById('auth-banner');
     const auth = getAuth(app);
+    const fns = getFunctions(app);
     onAuthStateChanged(auth, (u) => {
       if (u) {
         authBanner.style.display = 'none';
@@ -559,75 +561,36 @@
 
     async function startHand(tableId) {
       if (window.jamlog) window.jamlog.push('hand.start.click');
-      const seatsCol = collection(doc(db, 'tables', tableId), 'seats');
       try {
         await awaitAuthReady();
-        const snap = await getDocs(query(seatsCol, orderBy('seatIndex', 'asc')));
-        const occupied = [];
-        snap.forEach((d) => {
-          const s = d.data();
-          if (s.occupiedBy) occupied.push(s.seatIndex);
-        });
-        const path = handDocPath(tableId);
-        const stateRef = doc(db, path);
-        const stateSnap = await getDoc(stateRef);
-        const currentState = stateSnap.exists() ? stateSnap.data() : null;
-        if (occupied.length < 2) {
-          const handNo = typeof currentState?.handNo === 'number' ? currentState.handNo : 0;
-          await setDoc(stateRef, { handNo, dealerSeat: null, sbSeat: null, bbSeat: null, toActSeat: null, updatedAt: serverTimestamp() }, { merge: true });
-          if (window.jamlog) window.jamlog.push('hand.start.fail', { code: 'not-enough-players', message: 'Need 2+ players' });
-          alert('Need 2+ players');
-          return;
-        }
-        const next = (arr, val) => arr[(arr.indexOf(val) + 1) % arr.length];
-        let dealer;
-        if (currentState && occupied.includes(currentState.dealerSeat)) dealer = next(occupied, currentState.dealerSeat);
-        else dealer = occupied[0];
-        const sbSeat = next(occupied, dealer);
-        const bbSeat = next(occupied, sbSeat);
-        const toActSeat = next(occupied, bbSeat);
-        const handNo = (typeof currentState?.handNo === 'number' ? currentState.handNo : 0) + 1;
-        const tableData = tablesData[tableId] || {};
-        const sb = tableData?.blinds?.sbCents || 0;
-        const bb = tableData?.blinds?.bbCents || 0;
-        const commits = {};
-        commits[String(sbSeat)] = sb;
-        commits[String(bbSeat)] = bb;
-        const payload = {
-          handNo,
-          dealerSeat: dealer,
-          sbSeat,
-          bbSeat,
-          toActSeat,
-          street: 'preflop',
-          betToMatchCents: bb,
-          commits,
-          lastAggressorSeat: bbSeat,
-          updatedAt: serverTimestamp(),
-        };
-        const uid = auth.currentUser?.uid || 'anon';
-        const tRef = doc(db, `tables/${tableId}`);
-        const tSnap = await getDoc(tRef);
-        const createdByUid = tSnap.exists() ? (tSnap.data().createdByUid || null) : null;
-        const isAdmin = !!(createdByUid && createdByUid === uid);
-        logEvent('hand.start.ruleProbe', { tableId, path, uid, createdByUid, isAdmin, keys: Object.keys(payload) });
-        if (window.jamlog) window.jamlog.push('hand.start.payload.keys', { keys: Object.keys(payload) });
-        await setDoc(stateRef, payload, { merge: true });
-        logEvent('hand.start.ok', { path });
-        if (window.jamlog) window.jamlog.push('hand.start.ok', { handNo, dealerSeat: dealer, sbSeat, bbSeat, toActSeat, street:'preflop' });
-      } catch (err) {
         const path = handDocPath(tableId);
         const uid = auth.currentUser?.uid || 'anon';
-        const tRef = doc(db, `tables/${tableId}`);
         let createdByUid = null;
         try {
-          const tSnap = await getDoc(tRef);
+          const tSnap = await getDoc(doc(db, `tables/${tableId}`));
           createdByUid = tSnap.exists() ? (tSnap.data().createdByUid || null) : null;
         } catch {}
         const isAdmin = !!(createdByUid && createdByUid === uid);
-        logEvent('hand.start.fail', { code: err?.code, message: err?.message, path, uid, createdByUid, isAdmin });
-        if (window.jamlog) window.jamlog.push('hand.start.fail', { code: err?.code, message: err?.message });
-        alert('Error starting hand.');
+        logEvent('hand.start.ruleProbe', { tableId, path, uid, createdByUid, isAdmin, keys: [] });
+        const callable = httpsCallable(fns, 'startHand');
+        await callable({ tableId });
+        logEvent('hand.start.ok', { path });
+        if (window.jamlog) window.jamlog.push('hand.start.ok');
+      } catch (err) {
+        const code = err?.code;
+        const msg = err?.message;
+        const path = handDocPath(tableId);
+        const uid = auth.currentUser?.uid || 'anon';
+        let createdByUid = null;
+        try {
+          const tSnap = await getDoc(doc(db, `tables/${tableId}`));
+          createdByUid = tSnap.exists() ? (tSnap.data().createdByUid || null) : null;
+        } catch {}
+        const isAdmin = !!(createdByUid && createdByUid === uid);
+        logEvent('hand.start.fail', { code, message: msg, path, uid, createdByUid, isAdmin });
+        if (window.jamlog) window.jamlog.push('hand.start.fail', { code, message: msg });
+        if (code === 'failed-precondition') alert('Need 2+ players');
+        else alert('Error starting hand.');
       }
     }
     startTablesListener();

--- a/public/table.html
+++ b/public/table.html
@@ -32,6 +32,7 @@
       writeBatch, runTransaction, increment, getDoc
     } from "https://www.gstatic.com/firebasejs/10.12.5/firebase-firestore.js";
     import { awaitAuthReady, auth } from "/auth.js";
+    import { getFunctions, httpsCallable } from "https://www.gstatic.com/firebasejs/10.12.5/firebase-functions.js";
       import { handDocPath } from "/js/dbPaths.js";
       import { logEvent } from "/js/debug.js";
 
@@ -54,6 +55,7 @@
 
     const params = new URLSearchParams(window.location.search);
     const tableId = params.get('id');
+    const fns = getFunctions(app);
     document.body.classList.add('variant-v1');
     if (window.jamlog) window.jamlog.setTableId(tableId || null);
     const errorEl = document.getElementById('error');
@@ -496,68 +498,32 @@
 
     async function startHand() {
       if (window.jamlog) window.jamlog.push('hand.start.click');
-      const occupied = seatData.filter(s => s.occupiedBy).map(s => s.seatIndex).sort((a,b) => a - b);
       try {
         await awaitAuthReady();
         const path = handDocPath(tableId);
-        const handRef = doc(db, path);
-        let currentState = handState;
-        if (!currentState) {
-          const snap = await getDoc(handRef);
-          currentState = snap.exists() ? snap.data() : null;
-        }
-        if (occupied.length < 2) {
-          const handNo = typeof currentState?.handNo === 'number' ? currentState.handNo : 0;
-          await setDoc(handRef, { handNo, dealerSeat: null, sbSeat: null, bbSeat: null, toActSeat: null, updatedAt: serverTimestamp() }, { merge: true });
-          if (window.jamlog) window.jamlog.push('hand.start.fail', { code: 'not-enough-players', message: 'Need 2+ players' });
-          alert('Need 2+ players');
-          return;
-        }
-        const next = (arr, val) => arr[(arr.indexOf(val) + 1) % arr.length];
-        let dealer;
-        if (currentState && occupied.includes(currentState.dealerSeat)) {
-          dealer = next(occupied, currentState.dealerSeat);
-        } else {
-          dealer = occupied[0];
-        }
-        const sbSeat = next(occupied, dealer);
-        const bbSeat = next(occupied, sbSeat);
-        const toActSeat = next(occupied, bbSeat);
-        const handNo = (typeof currentState?.handNo === 'number' ? currentState.handNo : 0) + 1;
-        const sb = tableData?.blinds?.sbCents || 0;
-        const bb = tableData?.blinds?.bbCents || 0;
-        const commits = {};
-        commits[String(sbSeat)] = sb;
-        commits[String(bbSeat)] = bb;
-        foldedSeats.clear();
-        const payload = {
-          handNo,
-          dealerSeat: dealer,
-          sbSeat,
-          bbSeat,
-          toActSeat,
-          street: 'preflop',
-          betToMatchCents: bb,
-          commits,
-          lastAggressorSeat: bbSeat,
-          updatedAt: serverTimestamp(),
-        };
         const uid = auth.currentUser?.uid || 'anon';
-        const createdByUid = tableData?.createdByUid || null;
+        let createdByUid = null;
+        try {
+          const tSnap = await getDoc(doc(db, `tables/${tableId}`));
+          createdByUid = tSnap.exists() ? (tSnap.data().createdByUid || null) : null;
+        } catch {}
         const isAdmin = !!(createdByUid && createdByUid === uid);
-        logEvent('hand.start.ruleProbe', { tableId, path, uid, createdByUid, isAdmin, keys: Object.keys(payload) });
-        if (window.jamlog) window.jamlog.push('hand.start.payload.keys', { keys: Object.keys(payload) });
-        await setDoc(handRef, payload, { merge: true });
+        logEvent('hand.start.ruleProbe', { tableId, path, uid, createdByUid, isAdmin, keys: [] });
+        const callable = httpsCallable(fns, 'startHand');
+        await callable({ tableId });
         logEvent('hand.start.ok', { path });
-        if (window.jamlog) window.jamlog.push('hand.start.ok', { handNo, dealerSeat: dealer, sbSeat, bbSeat, toActSeat, street:'preflop' });
+        if (window.jamlog) window.jamlog.push('hand.start.ok');
       } catch (err) {
+        const code = err?.code;
+        const msg = err?.message;
         const path = handDocPath(tableId);
         const uid = auth.currentUser?.uid || 'anon';
         const createdByUid = tableData?.createdByUid || null;
         const isAdmin = !!(createdByUid && createdByUid === uid);
-        logEvent('hand.start.fail', { code: err?.code, message: err?.message, path, uid, createdByUid, isAdmin });
-        if (window.jamlog) window.jamlog.push('hand.start.fail', { code: err?.code, message: err?.message });
-        alert('Error starting hand.');
+        logEvent('hand.start.fail', { code, message: msg, path, uid, createdByUid, isAdmin });
+        if (window.jamlog) window.jamlog.push('hand.start.fail', { code, message: msg });
+        if (code === 'failed-precondition') alert('Need 2+ players');
+        else alert('Error starting hand.');
       }
     }
 


### PR DESCRIPTION
## Summary
- add startHand callable Cloud Function and export it
- call startHand from table and admin pages instead of client writes

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c6facd79f8832e80f86a3690ad36dc