### PR TITLE
Fix action worker queue and hand-start dedupe

### DIFF
--- a/functions/src/startHand.ts
+++ b/functions/src/startHand.ts
@@ -20,6 +20,11 @@ export const startHand = onCall(async (request) => {
     ]);
 
     const hand = handSnap.data() as any;
+    const nextHandNo = (typeof hand?.handNo === 'number' ? hand.handNo : 0) + 1;
+    if (hand?.handNo === nextHandNo) {
+      // Idempotent: hand already exists for this hand number
+      return { ok: true };
+    }
     if (hand?.street) {
       // Hand already started; idempotent return
       return { ok: true };
@@ -43,7 +48,7 @@ export const startHand = onCall(async (request) => {
     const sbSeat = next(occupied, dealer);
     const bbSeat = next(occupied, sbSeat);
     const toActSeat = next(occupied, bbSeat);
-    const handNo = (typeof hand?.handNo === 'number' ? hand.handNo : 0) + 1;
+    const handNo = nextHandNo;
 
     const table = tableSnap.data() as any || {};
     const sb = table?.blinds?.sbCents || 0;

--- a/public/admin.html
+++ b/public/admin.html
@@ -184,6 +184,7 @@
   <script type="module">
     import { app } from "/firebase-init.js";
     import { db, dollars, parseDollarsToCents, renderCurrentPlayerControls, isDebug } from "/common.js";
+    import { startActionWorker } from "/adminWorker.js";
       import {
         collection, addDoc, serverTimestamp, query, orderBy, onSnapshot, where,
         doc, updateDoc, deleteDoc, setDoc, writeBatch, getDocs, getDoc
@@ -477,6 +478,7 @@
     const tablesData = {};
     const seatCounts = {};
     const seatUnsubs = {};
+    const actionWorkers = {};
     const renderTables = () => {
       const rows = Object.entries(tablesData)
         .sort((a, b) => (b[1].createdAt?.toMillis?.() || 0) - (a[1].createdAt?.toMillis?.() || 0))
@@ -526,6 +528,8 @@
             if (seatUnsubs[id]) seatUnsubs[id]();
             delete seatUnsubs[id];
             delete seatCounts[id];
+            if (actionWorkers[id]) actionWorkers[id]();
+            delete actionWorkers[id];
           } else {
             tablesData[id] = change.doc.data();
             if (!seatUnsubs[id]) {
@@ -539,6 +543,11 @@
                 seatCounts[id] = cnt;
                 renderTables();
               });
+            }
+            const t = tablesData[id];
+            const uid = auth.currentUser?.uid;
+            if (uid && t.createdByUid === uid && !actionWorkers[id]) {
+              actionWorkers[id] = startActionWorker(id, uid);
             }
           }
         });
@@ -593,6 +602,7 @@
         else alert('Error starting hand.');
       }
     }
+    await awaitAuthReady();
     startTablesListener();
 
     tablesBody?.addEventListener("click", async (e) => {
@@ -613,7 +623,14 @@
           alert("Error: " + (err?.message || err));
         }
       } else if (target.classList.contains("start-hand")) {
-        await startHand(id);
+        const btn = target;
+        if (btn.disabled) return;
+        btn.disabled = true;
+        try {
+          await startHand(id);
+        } finally {
+          // keep disabled until listener updates UI
+        }
       } else if (target.classList.contains("set-admin")) {
         try {
           await updateDoc(doc(db, 'tables', id), { createdByUid: auth.currentUser.uid });

--- a/public/table.html
+++ b/public/table.html
@@ -70,7 +70,13 @@
     auth.onAuthStateChanged((u) => {
       if (!u) return;
       if (!tableId) return;
-      startActionWorker(tableId, u.uid);
+
+      getDoc(doc(db, `tables/${tableId}`))
+        .then((s) => {
+          const isAdmin = s.exists() && s.data()?.createdByUid === u.uid;
+          if (isAdmin) startActionWorker(tableId, u.uid);
+        })
+        .catch((e) => console.error("host.check.error", e));
     });
     document.body.classList.add('variant-v1');
     if (window.jamlog) window.jamlog.setTableId(tableId || null);
@@ -107,6 +113,19 @@
     let seatCountDesync = false;
     const tableRef = tableId ? doc(db, 'tables', tableId) : null;
     const handRef = tableId ? doc(db, handDocPath(tableId)) : null;
+
+    let startBound = false;
+    function bindStartHand(btn) {
+      if (startBound) return;
+      startBound = true;
+      btn.addEventListener('click', async () => {
+        if (btn.disabled) return;
+        btn.disabled = true;
+        try { await startHand(); } finally {
+          // keep disabled until hand subscription confirms
+        }
+      }, { once: true });
+    }
 
     function subscribeHandState(tableId, onChange) {
       const path = handDocPath(tableId);
@@ -330,7 +349,7 @@
         startBtn.disabled = handActive || !enable;
         if (!startBtn.disabled) {
           startBtn.removeAttribute('title');
-          startBtn.addEventListener('click', startHand, { once: true });
+          bindStartHand(startBtn);
         } else if (handActive) {
           startBtn.title = 'Hand already in progress';
         }

--- a/src/adminWorker.ts
+++ b/src/adminWorker.ts
@@ -1,5 +1,5 @@
 import {
-  getFirestore, doc, collection, query, where, orderBy, limit,
+  getFirestore, doc, collection, query, where, limit,
   onSnapshot, runTransaction, serverTimestamp
 } from "firebase/firestore";
 
@@ -9,16 +9,23 @@ export function startActionWorker(tableId: string, adminUid: string) {
   const q = query(
     collection(db, `tables/${tableId}/actions`),
     where("applied", "==", false),
-    orderBy("createdAt", "asc"),
     limit(1)
   );
 
-  return onSnapshot(q, (snap) => {
-    snap.docChanges().forEach((ch) => {
-      if (ch.type !== "added") return;
-      applyAction(ch.doc.id).catch(e => console.error("srv.action.error", e));
-    });
-  });
+  return onSnapshot(
+    q,
+    (snap) => {
+      snap.docChanges().forEach((ch) => {
+        if (ch.type !== "added") return;
+        applyAction(ch.doc.id).catch((e) =>
+          console.error("srv.action.error", { code: e?.code, message: e?.message })
+        );
+      });
+    },
+    (err) => {
+      console.error("srv.action.listener_error", { code: err.code, message: err.message });
+    }
+  );
 
   async function applyAction(actionId: string) {
     const actionRef = doc(db, `tables/${tableId}/actions/${actionId}`);

--- a/src/lib/poker/actions.ts
+++ b/src/lib/poker/actions.ts
@@ -1,4 +1,4 @@
-import { addDoc, collection, serverTimestamp } from 'firebase/firestore';
+import { collection, doc, serverTimestamp, setDoc } from 'firebase/firestore';
 
 export type PlayerAction = {
   type: 'check' | 'call' | 'bet' | 'raise' | 'fold';
@@ -13,11 +13,14 @@ export async function enqueueAction(
   handNo: number,
   action: PlayerAction
 ) {
-  await addDoc(collection(db, `tables/${tableId}/actions`), {
+  const ref = doc(collection(db, `tables/${tableId}/actions`));
+  await setDoc(ref, {
     handNo,
     seat,
     ...action,
     createdByUid: uid,
     createdAt: serverTimestamp(),
+    applied: false,
+    clientTs: Date.now(),
   });
 }


### PR DESCRIPTION
## Summary
- make action worker consume unapplied actions without index and log listener failures
- enqueue actions with required metadata
- only table creators host workers and de-dupe hand starts in UI and server

## Testing
- `npm test` *(fails: tsx not found)*
- `npm install` *(fails: 403 Forbidden for tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68c70a3db010832e97ddc8de5a920fb9