### PR TITLE
Use server transaction for actions and track actor identity

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -545,7 +545,7 @@
             const t = tablesData[id];
             const uid = auth.currentUser?.uid;
             if (uid && t.createdByUid === uid && !actionWorkers[id]) {
-              actionWorkers[id] = startActionWorker(id, uid);
+              actionWorkers[id] = startActionWorker(id);
             }
           }
         });

--- a/public/table.html
+++ b/public/table.html
@@ -87,7 +87,7 @@
       getDoc(doc(db, `tables/${tableId}`))
         .then((s) => {
           const isAdmin = s.exists() && s.data()?.createdByUid === u.uid;
-          if (isAdmin) startActionWorker(tableId, u.uid);
+      if (isAdmin) startActionWorker(tableId);
         })
         .catch((e) => console.error("host.check.error", e));
     });
@@ -552,6 +552,13 @@
 
     function commitOf(state, seat){ return Number(state.commits?.[String(seat)] || 0); }
 
+    function disableActionButtons(disabled) {
+      ['btn-check','btn-call','btn-fold'].forEach(id => {
+        const el = document.getElementById(id);
+        if (el) el.disabled = disabled;
+      });
+    }
+
       function renderPlayerBoard() {
         const current = getCurrentPlayer();
         mySeatIndex = seatData.find(s => s.occupiedBy === current?.id)?.seatIndex ?? null;
@@ -615,6 +622,7 @@
       if (window.jamlog) window.jamlog.push('ui.action.click', { type, seat: mySeatIndex });
       if (handState?.toActSeat !== mySeatIndex) {
         if (window.jamlog) window.jamlog.push('ui.action.blocked', { type, seat: mySeatIndex, reason: 'not-your-turn' });
+        disableActionButtons(true);
         alert("It's not your turn");
         return;
       }
@@ -622,13 +630,16 @@
       const target = handState.betToMatchCents || 0;
       if (type === 'check' && myCommit !== target) {
         if (window.jamlog) window.jamlog.push('ui.action.blocked', { type, seat: mySeatIndex, reason: 'bet-to-match' });
+        disableActionButtons(true);
         return;
       }
       if (type === 'call' && myCommit >= target) {
         if (window.jamlog) window.jamlog.push('ui.action.blocked', { type, seat: mySeatIndex, reason: 'bet-to-match' });
+        disableActionButtons(true);
         return;
       }
       pending = type;
+      disableActionButtons(true);
       pendingTimer = setTimeout(() => { pending = null; renderPlayerBoard(); }, 500);
       renderPlayerBoard();
       const payload = { type };
@@ -646,12 +657,14 @@
 
     async function enqueueAction(action) {
       await awaitAuthReady();
-      const uid = auth.currentUser?.uid || 'anon';
+      const createdByUid = auth.currentUser?.uid || 'anon';
+      const actorUid = seatData[mySeatIndex]?.occupiedBy || null;
       await addDoc(collection(db, `tables/${tableId}/actions`), {
         handNo: handState?.handNo || 0,
         seat: mySeatIndex,
         ...action,
-        createdByUid: uid,
+        createdByUid,
+        actorUid,
         createdAt: serverTimestamp(),
         applied: false,
       });

--- a/src/adminWorker.ts
+++ b/src/adminWorker.ts
@@ -1,89 +1,90 @@
 import {
-  getFirestore, doc, collection, query, where, orderBy, limit,
-  onSnapshot, runTransaction, serverTimestamp
-} from "firebase/firestore";
+  getFirestore,
+  doc,
+  collection,
+  query,
+  where,
+  orderBy,
+  limit,
+  onSnapshot,
+  serverTimestamp,
+  getDoc,
+  updateDoc,
+} from 'firebase/firestore';
+import { getFunctions, httpsCallable } from 'firebase/functions';
 
-export function startActionWorker(tableId: string, adminUid: string) {
+export function startActionWorker(tableId: string) {
   const db = getFirestore();
+  const functions = getFunctions();
+  const takeActionTX = httpsCallable(functions, 'takeActionTX');
 
   const q = query(
     collection(db, `tables/${tableId}/actions`),
-    where("applied", "==", false),
-    orderBy("createdAt", "asc"),
+    where('applied', '==', false),
+    orderBy('createdAt', 'asc'),
     limit(1)
   );
 
   return onSnapshot(
     q,
-    (snap) => {
-      snap.docChanges().forEach((ch) => {
-        if (ch.type !== "added") return;
-        applyAction(ch.doc.id).catch((e) =>
-          console.error("srv.action.error", { code: e?.code, message: e?.message })
-        );
-      });
+    async (snap) => {
+      for (const docSnap of snap.docs) {
+        const a = docSnap.data() as any;
+        const actionRef = docSnap.ref;
+        const hsRef = doc(db, `tables/${tableId}/handState/current`);
+        const hsSnap = await getDoc(hsRef);
+        const hs = hsSnap.data() as any;
+        if (!hs || hs.toActSeat !== a.seat) {
+          await updateDoc(actionRef, {
+            applied: true,
+            invalid: true,
+            reason: 'not-your-turn',
+            appliedAt: serverTimestamp(),
+          });
+          continue;
+        }
+        const seatUid = hs?.seats?.[a.seat]?.uid;
+        if (a.actorUid && seatUid && a.actorUid !== seatUid) {
+          console.warn('worker.apply.warn', {
+            reason: 'seat-mismatch',
+            actionId: docSnap.id,
+            seat: a.seat,
+            actorUid: a.actorUid,
+            seatUid,
+          });
+        }
+        try {
+          await takeActionTX({
+            tableId,
+            action: {
+              handNo: a.handNo,
+              seat: a.seat,
+              type: a.type,
+              amountCents: a.amountCents ?? null,
+              actorUid: a.actorUid,
+              createdByUid: a.createdByUid,
+            },
+          });
+          await updateDoc(actionRef, {
+            applied: true,
+            appliedAt: serverTimestamp(),
+          });
+        } catch (err) {
+          console.error('worker.apply.error', err);
+          await updateDoc(actionRef, {
+            applied: true,
+            invalid: true,
+            reason: 'server-error',
+            appliedAt: serverTimestamp(),
+          });
+        }
+      }
     },
     (err) => {
-      console.error("srv.action.listener_error", { code: err.code, message: err.message });
+      console.error('srv.action.listener_error', {
+        code: err.code,
+        message: err.message,
+      });
     }
   );
-
-  async function applyAction(actionId: string) {
-    const actionRef = doc(db, `tables/${tableId}/actions/${actionId}`);
-    const hsRef = doc(db, `tables/${tableId}/handState/current`);
-
-    await runTransaction(db, async (tx) => {
-      const [aSnap, hsSnap] = await Promise.all([tx.get(actionRef), tx.get(hsRef)]);
-      if (!aSnap.exists()) return;
-      const a = aSnap.data() as any;
-      if (a.applied) return;
-
-      const hs = hsSnap.data() as any;
-      if (!hs) throw new Error("no-handstate");
-      if (a.handNo !== hs.handNo) throw new Error("stale-hand");
-      if (a.seat !== hs.toActSeat) throw new Error("not-your-turn");
-
-      const toMatch = hs.toMatch ?? 0;
-      const commits = { ...(hs.commits ?? {}) };
-      const cur = commits[a.seat] ?? 0;
-
-      const bumpVersion = (hs.version ?? 0) + 1;
-      const nextSeat = hs.toActSeat === 0 ? 1 : 0; // TODO: generalize ring order
-
-      if (a.type === "call") {
-        const delta = Math.max(0, toMatch - cur);
-        commits[a.seat] = cur + delta;
-        tx.update(hsRef, {
-          commits,
-          toActSeat: nextSeat,
-          version: bumpVersion,
-          updatedAt: serverTimestamp()
-        });
-      } else if (a.type === "fold") {
-        tx.update(hsRef, {
-          toActSeat: nextSeat,
-          folded: { ...(hs.folded ?? {}), [a.seat]: true },
-          version: bumpVersion,
-          updatedAt: serverTimestamp()
-        });
-      } else if (a.type === "check") {
-        tx.update(hsRef, {
-          toActSeat: nextSeat,
-          version: bumpVersion,
-          updatedAt: serverTimestamp()
-        });
-      } else {
-        throw new Error(`unsupported-action:${a.type}`);
-      }
-
-      tx.update(actionRef, {
-        applied: true,
-        appliedAt: serverTimestamp(),
-        appliedBy: adminUid
-      });
-    });
-
-    console.log("srv.action.applied", { actionId });
-  }
 }
-

--- a/src/lib/poker/actions.ts
+++ b/src/lib/poker/actions.ts
@@ -9,8 +9,9 @@ export async function enqueueAction(
   db: any,
   tableId: string,
   seat: number,
-  uid: string,
+  createdByUid: string,
   handNo: number,
+  actorUid: string,
   action: PlayerAction
 ) {
   const ref = doc(collection(db, `tables/${tableId}/actions`));
@@ -18,7 +19,8 @@ export async function enqueueAction(
     handNo,
     seat,
     ...action,
-    createdByUid: uid,
+    createdByUid,
+    actorUid,
     createdAt: serverTimestamp(),
     applied: false,
     clientTs: Date.now(),

--- a/src/poker/tx/call.ts
+++ b/src/poker/tx/call.ts
@@ -8,7 +8,7 @@ export async function call(
   handNo: number,
   amountCents?: number
 ): Promise<void> {
-  await enqueueAction(db, tableId, seat, uid, handNo, {
+  await enqueueAction(db, tableId, seat, uid, handNo, uid, {
     type: 'call',
     amountCents,
   });

--- a/src/poker/tx/check.ts
+++ b/src/poker/tx/check.ts
@@ -7,5 +7,5 @@ export async function check(
   uid: string,
   handNo: number
 ): Promise<void> {
-  await enqueueAction(db, tableId, seat, uid, handNo, { type: 'check' });
+  await enqueueAction(db, tableId, seat, uid, handNo, uid, { type: 'check' });
 }

--- a/src/poker/tx/fold.ts
+++ b/src/poker/tx/fold.ts
@@ -7,5 +7,5 @@ export async function fold(
   uid: string,
   handNo: number
 ): Promise<void> {
-  await enqueueAction(db, tableId, seat, uid, handNo, { type: 'fold' });
+  await enqueueAction(db, tableId, seat, uid, handNo, uid, { type: 'fold' });
 }


### PR DESCRIPTION
## Summary
- include `actorUid` when enqueueing actions
- route pending actions through `takeActionTX` server transaction
- harden UI against duplicate or out-of-turn actions

## Testing
- `npm test` *(fails: tsx not found)*
- `npm install` *(fails: 403 Forbidden for tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68c715ef2b90832ead913c2e91d1ef33