### PR TITLE
Normalize action processing via actionId

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -74,7 +74,10 @@ service cloud.firestore {
       match /actions/{actionId} {
         allow read: if true;
         allow create: if request.auth != null;
-        allow update, delete: if false;
+        allow update: if isAdmin(tableId) &&
+          request.resource.data.diff(resource.data).changedKeys()
+            .hasOnly(['applied','appliedAt','invalid','reason','error']);
+        allow delete: if false;
       }
     }
 


### PR DESCRIPTION
## Summary
- Admin worker now calls `takeActionTX` with `{tableId, actionId}` and records applied/invalid results
- Cloud Function `takeActionTX` loads and validates the action document before mutating hand state
- Firestore rules permit admins to update action docs with processing outcomes

## Testing
- `npm test` *(fails: ReferenceError: describe is not defined)*


------
https://chatgpt.com/codex/tasks/task_e_68c76f45fd70832eb73383c8d7727410