### PR TITLE
Implement betting pipeline and admin street controls

### DIFF
--- a/functions/src/forceAdvanceStreet.ts
+++ b/functions/src/forceAdvanceStreet.ts
@@ -1,0 +1,56 @@
+import { onCall, HttpsError } from 'firebase-functions/v2/https';
+import { FieldValue } from 'firebase-admin/firestore';
+import { db } from './admin';
+
+function nextStreet(street: string) {
+  return street === 'preflop' ? 'flop' : street === 'flop' ? 'turn' : street === 'turn' ? 'river' : 'showdown';
+}
+function nextActiveSeat(seats: any[], start: number): number | null {
+  for (let step = 1; step <= 9; step++) {
+    const idx = (start + step) % 9;
+    const s = seats[idx];
+    if (s?.uid) return idx;
+  }
+  return null;
+}
+function streetStarter(hand: any, seats: any[]) {
+  if (hand.street === 'preflop') {
+    const bb = typeof hand.bbSeat === 'number' ? hand.bbSeat : hand.dealerSeat ?? 0;
+    return nextActiveSeat(seats, bb);
+  }
+  return nextActiveSeat(seats, hand.dealerSeat ?? 0);
+}
+
+export const forceAdvanceStreet = onCall(async (req) => {
+  const { tableId } = req.data || {};
+  const uid = req.auth?.uid;
+  if (!uid) throw new HttpsError('unauthenticated', 'auth-required');
+  if (!tableId) throw new HttpsError('invalid-argument', 'missing-table');
+
+  const tableRef = db.doc(`tables/${tableId}`);
+  const handRef = db.doc(`tables/${tableId}/handState/current`);
+
+  await db.runTransaction(async (tx) => {
+    const [tSnap, hSnap] = await Promise.all([tx.get(tableRef), tx.get(handRef)]);
+    const table = tSnap.data() as any;
+    const hand = hSnap.data() as any;
+    if (!table || !hand) throw new HttpsError('failed-precondition', 'missing-docs');
+    if (table.createdByUid !== uid) throw new HttpsError('permission-denied', 'admin-only');
+
+    const seats = (table.seats as any[]) ?? [];
+    const street = nextStreet(hand.street);
+    const toActSeat = street === 'showdown' ? null : streetStarter(hand, seats);
+
+    tx.update(handRef, {
+      street,
+      betToMatchCents: 0,
+      lastAggressorSeat: null,
+      toActSeat,
+      updatedAt: FieldValue.serverTimestamp(),
+      version: FieldValue.increment(1),
+      lastActionId: 'admin-force-next-street',
+    });
+  });
+
+  return { ok: true };
+});

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -5,6 +5,7 @@ import { onRequest } from "firebase-functions/v2/https";
 import { onDocumentWritten, onDocumentUpdated, onDocumentCreated } from "firebase-functions/v2/firestore";
 
 export { takeActionTX } from "./takeActionTX";
+export { forceAdvanceStreet } from "./forceAdvanceStreet";
 export { leaveSeatTX } from "./leaveSeatTX";
 export { onHandEndCleanup } from "./handEnd";
 export { pokerCall } from "./pokerCall";

--- a/functions/src/takeActionTX.ts
+++ b/functions/src/takeActionTX.ts
@@ -2,44 +2,71 @@ import { onCall, HttpsError, CallableRequest } from 'firebase-functions/v2/https
 import { FieldValue } from 'firebase-admin/firestore';
 import { db } from './admin';
 
-// ---- helpers ----
+// ---------- helpers ----------
 const sum = (obj: Record<string, number>) =>
   Object.values(obj || {}).reduce((m, v) => m + Number(v || 0), 0);
 
-function nextActiveSeat(seatDocs: any[], hand: any, start: number): number {
-  const total = 9;
+function loadSeatDocsSnapToArray(seatsSnap: FirebaseFirestore.QuerySnapshot) {
+  const seats: any[] = [];
+  seatsSnap.forEach((d) => seats.push({ id: d.id, ...d.data() }));
+  return seats;
+}
+
+function isOccupied(sd: any) {
+  return !!(sd?.occupiedBy || sd?.uid);
+}
+
+function activeSeatIndices(seats: any[], hand: any): number[] {
   const folded = new Set((hand?.folded ?? []).map((n: any) => Number(n)));
-  for (let i = 1; i <= total; i++) {
-    const idx = (start + i) % total;
-    const sd = seatDocs.find((d) => d?.seatIndex === idx);
-    const occupied = !!(sd?.occupiedBy || sd?.uid);
-    if (occupied && !folded.has(idx)) return idx;
+  return seats.filter(isOccupied).map((s) => s.seatIndex).filter((i) => !folded.has(i)).sort((a,b)=>a-b);
+}
+
+function nextActiveSeat(seats: any[], hand: any, start: number): number {
+  const folded = new Set((hand?.folded ?? []).map((n: any) => Number(n)));
+  for (let step = 1; step <= 9; step++) {
+    const idx = (start + step) % 9;
+    const sd = seats.find((s) => s.seatIndex === idx);
+    if (sd && isOccupied(sd) && !folded.has(idx)) return idx;
   }
   return start;
 }
-function streetStarter(hand: any, seatDocs: any[]) {
+
+function streetStarter(hand: any, seats: any[]) {
   if (hand.street === 'preflop') {
-    const bb = typeof hand.bbSeat === 'number' ? hand.bbSeat : hand.dealerSeat;
-    return nextActiveSeat(seatDocs, hand, bb);
+    const bb = typeof hand.bbSeat === 'number' ? hand.bbSeat : hand.dealerSeat ?? 0;
+    return nextActiveSeat(seats, hand, bb);
   }
-  return nextActiveSeat(seatDocs, hand, hand.dealerSeat ?? 0);
+  return nextActiveSeat(seats, hand, hand.dealerSeat ?? 0);
 }
+
 function nextStreet(street: string) {
   return street === 'preflop' ? 'flop'
        : street === 'flop'    ? 'turn'
        : street === 'turn'    ? 'river'
        : 'showdown';
 }
-function advanceStreet(hand: any, seatDocs: any[]) {
+
+function advanceStreet(hand: any, seats: any[]) {
   const street = nextStreet(hand.street);
-  const toAct = street === 'showdown' ? null : streetStarter(hand, seatDocs);
+  const toAct = street === 'showdown' ? null : streetStarter(hand, seats);
   return {
     street,
     betToMatchCents: 0,
     lastAggressorSeat: null,
     toActSeat: toAct,
     updatedAt: FieldValue.serverTimestamp(),
+    version: FieldValue.increment(1),
   };
+}
+
+function minRaiseIncrement(hand: any, table: any): number {
+  const bb = Number(table?.blinds?.bbCents ?? 0);
+  // Classic rule: minimum raise size = max(bb, current bet increment)
+  const toMatch = Number(hand?.betToMatchCents ?? 0);
+  const lastAgg = hand?.lastAggressorSeat;
+  const lastAggCommit = Number(hand?.commits?.[String(lastAgg)] ?? 0);
+  const inc = Math.max(0, toMatch - lastAggCommit);
+  return Math.max(bb, inc);
 }
 
 export const takeActionTX = onCall(async (request: CallableRequest<any>) => {
@@ -56,7 +83,7 @@ export const takeActionTX = onCall(async (request: CallableRequest<any>) => {
       tx.get(handRef),
       tx.get(tableRef),
       tx.get(actionRef),
-      tx.get(seatsCol), // read actual seat docs
+      tx.get(seatsCol),
     ]);
 
     const hand = handSnap.data() as any;
@@ -65,13 +92,11 @@ export const takeActionTX = onCall(async (request: CallableRequest<any>) => {
     if (!hand || !table || !action) throw new HttpsError('failed-precondition', 'missing-docs');
     if (action.applied === true) return; // idempotent
 
-    const seats: any[] = [];
-    seatsSnap.forEach((d) => seats.push({ id: d.id, ...d.data() }));
-
+    const seats = loadSeatDocsSnapToArray(seatsSnap);
     const seatIdx = Number(action.seat);
     if (hand.toActSeat !== seatIdx) throw new HttpsError('failed-precondition', 'not-your-turn');
 
-    // Validate actor: accept either occupiedBy or uid on the seat doc
+    // Validate actor matches seat
     const seatDoc = seats.find((s) => s.seatIndex === seatIdx) || {};
     const seatOccupant = seatDoc?.occupiedBy || seatDoc?.uid || null;
     if (action.actorUid && seatOccupant && action.actorUid !== seatOccupant) {
@@ -80,48 +105,73 @@ export const takeActionTX = onCall(async (request: CallableRequest<any>) => {
 
     const commits: Record<string, number> = { ...(hand.commits ?? {}) };
     const key = String(seatIdx);
-    const myCommit = commits[key] ?? 0;
+    const myCommit = Number(commits[key] ?? 0);
     const toMatch = Number(hand.betToMatchCents ?? 0);
     const owe = Math.max(0, toMatch - myCommit);
 
     const starter = streetStarter(hand, seats);
     const nextSeat = nextActiveSeat(seats, hand, seatIdx);
-    const actives = seats
-      .filter((s) => !!(s?.occupiedBy || s?.uid))
-      .map((s) => s.seatIndex)
-      .sort((a, b) => a - b);
+    const actives = activeSeatIndices(seats, hand);
 
     let updates: any = {
       updatedAt: FieldValue.serverTimestamp(),
       lastActionId: actionId,
     };
 
-    if (action.type === 'check') {
-      if (owe > 0) throw new HttpsError('failed-precondition', 'cannot-check');
-      const allMatched = actives.every((i) => (commits[String(i)] ?? 0) >= toMatch);
-      if (allMatched && nextSeat === starter) {
-        updates = { ...updates, ...advanceStreet(hand, seats), potCents: sum(commits) };
-      } else {
-        updates = { ...updates, toActSeat: nextSeat, potCents: sum(commits) };
-      }
-    } else if (action.type === 'call') {
-      if (owe > 0) {
-        commits[key] = myCommit + owe;
-        updates.commits = commits;
-      }
+    const type: string = action.type;
+
+    if (type === 'check') {
+      if (owe > 0) throw new HttpsError('failed-precondition', 'cannot-check-when-owed');
+      // everyone matched?
+      const allMatched = actives.every((i) => (Number(commits[String(i)] ?? 0) >= toMatch));
       updates.potCents = sum(commits);
-      const allMatched = actives.every((i) => (commits[String(i)] ?? 0) >= toMatch);
       if (allMatched && nextSeat === starter) {
         updates = { ...updates, ...advanceStreet(hand, seats) };
       } else {
         updates.toActSeat = nextSeat;
       }
+    } else if (type === 'call') {
+      if (owe > 0) {
+        commits[key] = myCommit + owe;
+        updates.commits = commits;
+      }
+      updates.potCents = sum(commits);
+      const allMatched = actives.every((i) => (Number(commits[String(i)] ?? 0) >= toMatch));
+      if (allMatched && nextSeat === starter) {
+        updates = { ...updates, ...advanceStreet(hand, seats) };
+      } else {
+        updates.toActSeat = nextSeat;
+      }
+    } else if (type === 'bet' || type === 'raise') {
+      const target = Number(action.amountCents);
+      if (!Number.isFinite(target) || target <= myCommit) {
+        throw new HttpsError('invalid-argument', 'bad-amount');
+      }
+      // bet only allowed when no bet outstanding; raise when there is one
+      if (type === 'bet' && toMatch !== 0) throw new HttpsError('failed-precondition', 'cannot-bet-when-bet-exists');
+      if (type === 'raise' && toMatch === 0) throw new HttpsError('failed-precondition', 'cannot-raise-when-no-bet');
+
+      const minInc = minRaiseIncrement(hand, table);
+      const minTarget = Math.max(toMatch + minInc, myCommit + minInc);
+      if (target < minTarget) {
+        throw new HttpsError('failed-precondition', 'min-raise-not-met');
+      }
+
+      // Move my total commit up to `target`; set new toMatch to target
+      commits[key] = target;
+      updates.commits = commits;
+      updates.potCents = sum(commits);
+      updates.betToMatchCents = target;
+      updates.lastAggressorSeat = seatIdx;
+
+      // After raise, action goes to next seat (never closes immediately)
+      updates.toActSeat = nextSeat;
     } else {
-      throw new HttpsError('invalid-argument', 'unsupported-in-02A');
+      throw new HttpsError('invalid-argument', 'unsupported-action');
     }
 
     tx.update(handRef, updates);
-    // Mark the action as applied from the server (reduces dependence on client/rules timing)
+    // Mark action applied atomically
     tx.update(actionRef, {
       applied: true,
       invalid: false,
@@ -129,4 +179,3 @@ export const takeActionTX = onCall(async (request: CallableRequest<any>) => {
     });
   });
 });
-

--- a/public/table.html
+++ b/public/table.html
@@ -15,6 +15,7 @@
       <button id="chat-toggle" class="toolbar-btn" aria-pressed="false" style="margin-left:auto;margin-right:8px;">Chat</button>
       <span id="debug-chip" class="small" style="cursor:pointer;padding:4px 8px;border:1px solid #334155;border-radius:8px;">Debug: OFF</span>
     </nav>
+    <button id="btn-next-street" data-admin-only style="display:none">Next Street (Admin)</button>
     <div id="you"></div>
     <div id="error" class="card" style="display:none;"></div>
     <div id="table-info" class="card" style="margin-top:16px;"></div>
@@ -668,6 +669,7 @@
         createdByUid,
         actorUid,
         createdAt: serverTimestamp(),
+        clientTs: Date.now(),
         applied: false,
       });
     }
@@ -678,6 +680,38 @@
       const pos = handData?.positions || {};
       const folded = Object.keys(handData?.folded || {}).join(',');
       debugBox.textContent = `id=${tableId}\ncurrentHandId=${tableData?.currentHandId ?? 'null'}\nnextDealerId=${tableData?.nextDealerId ?? 'null'}\nnextDealerName=${tableData?.nextDealerName ?? 'null'}\nnextVariantId=${tableData?.nextVariantId ?? 'null'}\npositions=${pos.dealerSeatNum ?? 'null'},${pos.sbSeatNum ?? 'null'},${pos.bbSeatNum ?? 'null'}\nstage=${handData?.stage ?? 'null'}\nactorSeatNum=${handData?.actorSeatNum ?? 'null'}\nlastAggressorSeatNum=${handData?.lastAggressorSeatNum ?? 'null'}\nroundStartSeatNum=${handData?.roundStartSeatNum ?? 'null'}\ntoCallCents=${handData?.toCallCents ?? 'null'}\nminRaiseCents=${handData?.minRaiseCents ?? 'null'}\ndeckIndex=${handData?.deckIndex ?? 'null'}\nboard=${JSON.stringify(handData?.board || [])}\nfolded=${folded}\nactiveSeatCount=${seatData.filter(s => s.active).length}`;
+    }
+  </script>
+  <script type="module">
+    import { getFunctions, httpsCallable } from "https://www.gstatic.com/firebasejs/10.12.5/firebase-functions.js";
+    import { getFirestore, doc, getDoc } from "https://www.gstatic.com/firebasejs/10.12.5/firebase-firestore.js";
+    import { auth, awaitAuthReady } from "/auth.js";
+
+    const params = new URLSearchParams(location.search);
+    const tableId = params.get('id');
+    const db = getFirestore();
+    const fns = getFunctions();
+
+    await awaitAuthReady();
+    const uid = auth.currentUser?.uid || null;
+
+    if (tableId && uid) {
+      const tSnap = await getDoc(doc(db, `tables/${tableId}`));
+      const isAdmin = tSnap.exists() && tSnap.data()?.createdByUid === uid;
+      const btn = document.getElementById('btn-next-street');
+      if (isAdmin && btn) {
+        btn.style.display = '';
+        btn.addEventListener('click', async () => {
+          try {
+            await httpsCallable(fns, 'forceAdvanceStreet')({ tableId });
+            if (window.jamlog) window.jamlog.push('admin.forceNextStreet.ok');
+          } catch (e) {
+            console.error(e);
+            if (window.jamlog) window.jamlog.push('admin.forceNextStreet.fail', { message: String(e?.message || e) });
+            alert('Failed to advance street');
+          }
+        });
+      }
     }
   </script>
 </body>

--- a/src/adminWorker.ts
+++ b/src/adminWorker.ts
@@ -21,41 +21,28 @@ export function startActionWorker(tableId: string) {
     limit(1)
   );
 
-  if ((window as any).jamlog) (window as any).jamlog.push('worker.start', { tableId });
+  if (window.jamlog) window.jamlog.push('worker.start', { tableId });
 
   return onSnapshot(
     q,
     async (snap) => {
       if (snap.empty) return;
-
       for (const docSnap of snap.docs) {
         const actionId = docSnap.id;
-
-        // Call the Cloud Function with { tableId, actionId }.
-        // The CF validates turn/actor, updates handState, and marks the action as applied.
         try {
           await takeActionTX({ tableId, actionId });
-
-          if ((window as any).jamlog) {
-            (window as any).jamlog.push('worker.cf.ok', { tableId, actionId });
-          }
-        } catch (err: any) {
-          // Do NOT try to write to /actions here (rules disallow updates).
+          if (window.jamlog) window.jamlog.push('worker.cf.ok', { tableId, actionId });
+        } catch (err) {
           const code = err?.code || 'unknown';
           const message = err?.message || String(err);
           console.error('worker.cf.error', { tableId, actionId, code, message });
-          if ((window as any).jamlog) {
-            (window as any).jamlog.push('worker.cf.error', { tableId, actionId, code, message });
-          }
+          if (window.jamlog) window.jamlog.push('worker.cf.error', { tableId, actionId, code, message });
         }
       }
     },
     (err) => {
       console.error('srv.action.listener_error', { code: err.code, message: err.message });
-      if ((window as any).jamlog) {
-        (window as any).jamlog.push('worker.sub.error', { code: err.code, message: err.message });
-      }
+      if (window.jamlog) window.jamlog.push('worker.sub.error', { code: err.code, message: err.message });
     }
   );
 }
-

--- a/src/lib/poker/actions.ts
+++ b/src/lib/poker/actions.ts
@@ -2,7 +2,7 @@ import { collection, doc, serverTimestamp, setDoc } from 'firebase/firestore';
 
 export type PlayerAction = {
   type: 'check' | 'call' | 'bet' | 'raise' | 'fold';
-  amountCents?: number;
+  amountCents?: number; // For bet/raise, this is the *new* betToMatch level (total to match), not the delta
 };
 
 export async function enqueueAction(
@@ -22,7 +22,7 @@ export async function enqueueAction(
     createdByUid,
     actorUid,
     createdAt: serverTimestamp(),
-    applied: false,
     clientTs: Date.now(),
+    applied: false,
   });
 }


### PR DESCRIPTION
## Summary
- align action enqueue payloads with client timestamps and add admin-only Next Street UI control
- update the admin worker to delegate actions to the new transactional Cloud Function
- overhaul takeActionTX to support betting flow and add a forceAdvanceStreet callable for admins

## Testing
- npm test *(fails: ReferenceError: describe is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68c8421891f4832ea914d6952ffa17fe