### PR TITLE
Add admin-only next street control

### DIFF
--- a/public/js/advanceStreet.js
+++ b/public/js/advanceStreet.js
@@ -1,0 +1,105 @@
+import { app } from "/firebase-init.js";
+import { getFunctions, httpsCallable } from "https://www.gstatic.com/firebasejs/10.12.5/firebase-functions.js";
+import { awaitAuthReady } from "/auth.js";
+import { logEvent } from "/js/debug.js";
+
+const functions = getFunctions(app);
+const advanceStreetCallable = httpsCallable(functions, "forceAdvanceStreet");
+
+let activeTableId = null;
+let listenerAttached = false;
+let toastContainer = null;
+
+const TOAST_DURATION = 4000;
+
+function ensureToastContainer() {
+  if (toastContainer && document.body.contains(toastContainer)) return toastContainer;
+  toastContainer = document.createElement("div");
+  toastContainer.className = "toast-container";
+  document.body.appendChild(toastContainer);
+  return toastContainer;
+}
+
+function showToast(message, variant = "info", options = {}) {
+  const { duration = TOAST_DURATION } = options;
+  const container = ensureToastContainer();
+  const toast = document.createElement("div");
+  toast.className = `toast toast--${variant}`;
+  toast.textContent = message;
+  container.appendChild(toast);
+
+  requestAnimationFrame(() => {
+    toast.classList.add("toast--visible");
+  });
+
+  let dismissed = false;
+  let timerId = null;
+
+  const remove = () => {
+    if (dismissed) return;
+    dismissed = true;
+    if (timerId) clearTimeout(timerId);
+    toast.classList.remove("toast--visible");
+    setTimeout(() => {
+      toast.remove();
+      if (!container.childElementCount) {
+        container.remove();
+        toastContainer = null;
+      }
+    }, 220);
+  };
+
+  if (duration > 0) {
+    timerId = setTimeout(remove, duration);
+  }
+
+  toast.addEventListener("click", remove);
+
+  return remove;
+}
+
+async function handleAdvanceClick(button) {
+  if (!activeTableId) return;
+  if (button.disabled) return;
+
+  button.disabled = true;
+  const tableId = activeTableId;
+
+  logEvent("ui.advanceStreet.start", { tableId });
+  if (window.jamlog) window.jamlog.push("ui.advanceStreet.start", { tableId });
+  const dismissInfo = showToast("Advancing street…", "info", { duration: 2000 });
+
+  try {
+    await awaitAuthReady();
+    await advanceStreetCallable({ tableId });
+    logEvent("ui.advanceStreet.ok", { tableId });
+    if (window.jamlog) window.jamlog.push("ui.advanceStreet.ok", { tableId });
+    dismissInfo();
+    showToast("Advanced to next street", "success");
+  } catch (err) {
+    const message = err?.message || "Unknown error";
+    logEvent("ui.advanceStreet.fail", { tableId, message });
+    if (window.jamlog) window.jamlog.push("ui.advanceStreet.fail", { tableId, message });
+    console.error("forceAdvanceStreet failed", err);
+    dismissInfo();
+    showToast(`Failed to advance street: ${message}`, "error");
+  } finally {
+    button.disabled = false;
+  }
+}
+
+function onDocumentClick(event) {
+  const target = event.target.closest("#btn-next-street");
+  if (!target) return;
+  event.preventDefault();
+  handleAdvanceClick(target);
+}
+
+export function initAdvanceStreet({ tableId }) {
+  if (!tableId) return;
+  activeTableId = tableId;
+  if (!listenerAttached) {
+    document.addEventListener("click", onDocumentClick);
+    listenerAttached = true;
+  }
+}

--- a/public/table.css
+++ b/public/table.css
@@ -64,3 +64,55 @@ body.variant-v1 .community-card.enter {
   pointer-events: none;
   opacity: .5;
 }
+
+#player-board .player-board__admin {
+  display: none;
+  justify-content: center;
+  margin-top: 8px;
+  gap: 8px;
+}
+
+body.is-table-admin #player-board .player-board__admin {
+  display: flex;
+}
+
+.toast-container {
+  position: fixed;
+  right: 24px;
+  bottom: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  z-index: 1000;
+}
+
+.toast {
+  background: rgba(15, 23, 42, 0.92);
+  border: 1px solid #334155;
+  border-radius: 12px;
+  padding: 12px 16px;
+  color: #e2e8f0;
+  font-size: 14px;
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.35);
+  opacity: 0;
+  transform: translateY(12px);
+  transition: opacity 0.2s ease, transform 0.2s ease;
+  pointer-events: auto;
+}
+
+.toast.toast--visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.toast.toast--success {
+  border-color: #22c55e;
+}
+
+.toast.toast--error {
+  border-color: #ef4444;
+}
+
+.toast.toast--info {
+  border-color: #38bdf8;
+}

--- a/public/table.html
+++ b/public/table.html
@@ -15,7 +15,6 @@
       <button id="chat-toggle" class="toolbar-btn" aria-pressed="false" style="margin-left:auto;margin-right:8px;">Chat</button>
       <span id="debug-chip" class="small" style="cursor:pointer;padding:4px 8px;border:1px solid #334155;border-radius:8px;">Debug: OFF</span>
     </nav>
-    <button id="btn-next-street" data-admin-only style="display:none">Next Street (Admin)</button>
     <div id="you"></div>
     <div id="error" class="card" style="display:none;"></div>
     <div id="table-info" class="card" style="margin-top:16px;"></div>
@@ -88,8 +87,17 @@
       const createdByUid = tSnap.exists() ? (tSnap.data()?.createdByUid || null) : null;
       const isAdmin = !!(createdByUid && createdByUid === u.uid);
       if (isAdmin) {
+        document.body.classList.add('is-table-admin');
         if (window.jamlog) window.jamlog.push('worker.attach', { tableId, isAdmin: true });
         startActionWorker(tableId);
+        try {
+          const { initAdvanceStreet } = await import('/js/advanceStreet.js');
+          initAdvanceStreet({ tableId });
+        } catch (err) {
+          console.error('Failed to load advance street controls', err);
+          logEvent('ui.advanceStreet.load.fail', { tableId, message: err?.message });
+          if (window.jamlog) window.jamlog.push('ui.advanceStreet.load.fail', { tableId, message: err?.message });
+        }
       } else {
         if (window.jamlog) window.jamlog.push('worker.skip', { tableId, isAdmin: false });
       }
@@ -578,7 +586,19 @@
           handNo: handState?.handNo || null,
         });
         boardEl.style.display = 'block';
-        boardEl.innerHTML = '<div style="display:flex; gap:8px; justify-content:center;"><button id="btn-check" class="action-btn" data-action="check">Check</button><button id="btn-call" class="action-btn" data-action="call">Call</button><button id="btn-fold" class="action-btn" data-action="fold">Fold</button></div><div style="display:flex; justify-content:center; margin-top:8px;"><button id="btn-leave-seat">Leave seat</button></div>';
+        boardEl.innerHTML = `
+          <div class="player-board__actions" style="display:flex; gap:8px; justify-content:center; flex-wrap:wrap;">
+            <button id="btn-check" class="action-btn" data-action="check" type="button">Check</button>
+            <button id="btn-call" class="action-btn" data-action="call" type="button">Call</button>
+            <button id="btn-fold" class="action-btn" data-action="fold" type="button">Fold</button>
+          </div>
+          <div id="admin-action-row" class="player-board__admin" data-admin-only>
+            <button id="btn-next-street" class="action-btn small" type="button">Next street</button>
+          </div>
+          <div style="display:flex; justify-content:center; margin-top:8px;">
+            <button id="btn-leave-seat" type="button">Leave seat</button>
+          </div>
+        `;
         const checkBtn = document.getElementById('btn-check');
         const callBtn = document.getElementById('btn-call');
         const foldBtn = document.getElementById('btn-fold');
@@ -680,38 +700,6 @@
       const pos = handData?.positions || {};
       const folded = Object.keys(handData?.folded || {}).join(',');
       debugBox.textContent = `id=${tableId}\ncurrentHandId=${tableData?.currentHandId ?? 'null'}\nnextDealerId=${tableData?.nextDealerId ?? 'null'}\nnextDealerName=${tableData?.nextDealerName ?? 'null'}\nnextVariantId=${tableData?.nextVariantId ?? 'null'}\npositions=${pos.dealerSeatNum ?? 'null'},${pos.sbSeatNum ?? 'null'},${pos.bbSeatNum ?? 'null'}\nstage=${handData?.stage ?? 'null'}\nactorSeatNum=${handData?.actorSeatNum ?? 'null'}\nlastAggressorSeatNum=${handData?.lastAggressorSeatNum ?? 'null'}\nroundStartSeatNum=${handData?.roundStartSeatNum ?? 'null'}\ntoCallCents=${handData?.toCallCents ?? 'null'}\nminRaiseCents=${handData?.minRaiseCents ?? 'null'}\ndeckIndex=${handData?.deckIndex ?? 'null'}\nboard=${JSON.stringify(handData?.board || [])}\nfolded=${folded}\nactiveSeatCount=${seatData.filter(s => s.active).length}`;
-    }
-  </script>
-  <script type="module">
-    import { getFunctions, httpsCallable } from "https://www.gstatic.com/firebasejs/10.12.5/firebase-functions.js";
-    import { getFirestore, doc, getDoc } from "https://www.gstatic.com/firebasejs/10.12.5/firebase-firestore.js";
-    import { auth, awaitAuthReady } from "/auth.js";
-
-    const params = new URLSearchParams(location.search);
-    const tableId = params.get('id');
-    const db = getFirestore();
-    const fns = getFunctions();
-
-    await awaitAuthReady();
-    const uid = auth.currentUser?.uid || null;
-
-    if (tableId && uid) {
-      const tSnap = await getDoc(doc(db, `tables/${tableId}`));
-      const isAdmin = tSnap.exists() && tSnap.data()?.createdByUid === uid;
-      const btn = document.getElementById('btn-next-street');
-      if (isAdmin && btn) {
-        btn.style.display = '';
-        btn.addEventListener('click', async () => {
-          try {
-            await httpsCallable(fns, 'forceAdvanceStreet')({ tableId });
-            if (window.jamlog) window.jamlog.push('admin.forceNextStreet.ok');
-          } catch (e) {
-            console.error(e);
-            if (window.jamlog) window.jamlog.push('admin.forceNextStreet.fail', { message: String(e?.message || e) });
-            alert('Failed to advance street');
-          }
-        });
-      }
     }
   </script>
 </body>


### PR DESCRIPTION
## Summary
- add an admin-only "Next street" button beside the table action controls
- dynamically import new advanceStreet module for admins and wire up toast notifications and jamlog tracking
- style the admin control and toast notifications for the table view

## Testing
- npm test *(fails: ReferenceError describe is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68c859d7da60832e85050e9b926c5502