### PR TITLE
Trigger takeAction callable after player enqueue

### DIFF
--- a/public/table.html
+++ b/public/table.html
@@ -56,6 +56,7 @@
       doc, setDoc, updateDoc, onSnapshot, collection, query, orderBy, serverTimestamp,
       writeBatch, runTransaction, increment, getDoc, addDoc
     } from "https://www.gstatic.com/firebasejs/10.12.5/firebase-firestore.js";
+    import { getFunctions, httpsCallable } from "https://www.gstatic.com/firebasejs/10.12.5/firebase-functions.js";
     import { awaitAuthReady, auth } from "/auth.js";
       import { handDocPath } from "/js/dbPaths.js";
       import { logEvent } from "/js/debug.js";
@@ -279,6 +280,8 @@
 
     const params = new URLSearchParams(window.location.search);
     const tableId = params.get('id');
+    const fns = getFunctions(app);
+    const takeActionTX = httpsCallable(fns, 'takeActionTX');
     const controlsRoot = document.getElementById('table-controls') || document;
     controlsRoot.addEventListener('click', async (e) => {
       const btn = e.target.closest('[data-action="start-hand"]');
@@ -996,6 +999,16 @@
           amountCents: amount,
           actorUid,
         });
+      }
+      try {
+        if (window.jamlog) window.jamlog.push('worker.apply.start', { tableId, actionId: docRef.id });
+        await takeActionTX({ tableId, actionId: docRef.id });
+        if (window.jamlog) window.jamlog.push('worker.apply.ok', { tableId, actionId: docRef.id });
+      } catch (err) {
+        const code = err?.code || 'unknown';
+        const message = err?.message || String(err);
+        if (window.jamlog) window.jamlog.push('worker.apply.fail', { tableId, actionId: docRef.id, code, message });
+        throw err;
       }
       return docRef;
     }

--- a/src/lib/poker/actions.ts
+++ b/src/lib/poker/actions.ts
@@ -13,7 +13,7 @@ export async function enqueueAction(
   handNo: number,
   actorUid: string,
   action: PlayerAction
-) {
+): Promise<string> {
   const ref = doc(collection(db, `tables/${tableId}/actions`));
   await setDoc(ref, {
     handNo,
@@ -25,4 +25,5 @@ export async function enqueueAction(
     clientTs: Date.now(),
     applied: false,
   });
+  return ref.id;
 }


### PR DESCRIPTION
## Summary
- call the takeActionTX callable from the table UI immediately after adding an action and emit jamlog telemetry around the attempt
- initialize the Firebase Functions client on the table page so player-enqueued actions can self-apply
- return the created action id from the shared enqueueAction helper for callers that need to invoke the callable

## Testing
- npm test *(fails: ReferenceError: describe is not defined)*


------
https://chatgpt.com/codex/tasks/task_e_68c884665da0832e95c71a2d8b718922