### PR TITLE
Disable Firebase preview workflow and document secret

### DIFF
--- a/.github/workflows/firebase-hosting-preview.yml
+++ b/.github/workflows/firebase-hosting-preview.yml
@@ -12,29 +12,32 @@ env:
   PROJECT_ID: jam-poker
 
 jobs:
-  hosting-preview:
-    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      id-token: write
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: "20"
-
-      - name: Install Firebase CLI
-        run: npm install -g firebase-tools
-
-      - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
-        with:
-          credentials_json: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JAM_POKER }}
-
-      - name: Deploy preview channel
-        run: firebase hosting:channel:deploy pr-${{ github.event.number }} --project "$PROJECT_ID" --json
+  # Preview deployments are currently disabled. Remove the comments below to
+  # re-enable the job using the FIREBASE_SERVICE_ACCOUNT secret.
+  # hosting-preview:
+  #   if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+  #   runs-on: ubuntu-latest
+  #   permissions:
+  #     contents: read
+  #     id-token: write
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #
+  #     - uses: actions/setup-node@v4
+  #       with:
+  #         node-version: "20"
+  #
+  #     - name: Install Firebase CLI
+  #       run: npm install -g firebase-tools
+  #
+  #     - name: Authenticate to Google Cloud
+  #       uses: google-github-actions/auth@v2
+  #       with:
+  #         projectId: jam-poker
+  #         credentials_json: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
+  #
+  #     - name: Deploy preview channel
+  #       run: firebase hosting:channel:deploy pr-${{ github.event.number }} --project "$PROJECT_ID" --json
 
   skip-preview:
     if: ${{ github.event.pull_request.head.repo.full_name != github.repository }}

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -6,6 +6,9 @@
 - Functions (gen2, us-central1): **ping**, **onSeatsChanged**, **onVariantChosen**, **onHandEnded**
 - GitHub CI: deploys Functions + Hosting (+ rules) on merges to **main**
 
+## GitHub Actions Secrets
+- `FIREBASE_SERVICE_ACCOUNT`: Service account JSON (base64 encoded) used by the disabled Hosting preview workflow. Required if the preview job is re-enabled.
+
 ## Current Features
 - Lobby/Admin basic UI
 - Players + wallets (CRUD) — dev rules (no auth yet)


### PR DESCRIPTION
## Summary
- comment out the Firebase Hosting preview job and note the FIREBASE_SERVICE_ACCOUNT secret for future re-enablement
- update docs to record the FIREBASE_SERVICE_ACCOUNT requirement for GitHub Actions

## Testing
- not run (workflow-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68c88710c2a8832e8d622e197fc79cb1