### PR TITLE
Ensure workflows handle missing npm lockfiles

### DIFF
--- a/.github/workflows/deploy-on-merge.yml
+++ b/.github/workflows/deploy-on-merge.yml
@@ -20,15 +20,33 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: '18'
+          cache: 'npm'
+          cache-dependency-path: |
+            package-lock.json
+            functions/package-lock.json
+
+      - name: Install deps (root)
+        run: |
+          if [ -f package-lock.json ]; then
+            npm ci
+          else
+            npm install
+          fi
 
       - name: Install Firebase CLI
         run: npm install -g firebase-tools
 
-      - name: Install Functions dependencies
-        run: npm --prefix functions ci
+      - name: Install deps (functions)
+        run: |
+          if [ -f functions/package-lock.json ]; then
+            npm ci --prefix functions
+          else
+            npm install --prefix functions
+          fi
 
       - name: Build Cloud Functions
         run: npm --prefix functions run build

--- a/.github/workflows/firebase-hosting-preview.yml
+++ b/.github/workflows/firebase-hosting-preview.yml
@@ -23,9 +23,30 @@ jobs:
   #   steps:
   #     - uses: actions/checkout@v4
   #
-  #     - uses: actions/setup-node@v4
+  #     - name: Setup Node
+  #       uses: actions/setup-node@v4
   #       with:
-  #         node-version: "20"
+  #         node-version: '18'
+  #         cache: 'npm'
+  #         cache-dependency-path: |
+  #           package-lock.json
+  #           functions/package-lock.json
+
+  #     - name: Install deps (root)
+  #       run: |
+  #         if [ -f package-lock.json ]; then
+  #           npm ci
+  #         else
+  #           npm install
+  #         fi
+
+  #     - name: Install deps (functions)
+  #       run: |
+  #         if [ -f functions/package-lock.json ]; then
+  #           npm ci --prefix functions
+  #         else
+  #           npm install --prefix functions
+  #         fi
   #
   #     - name: Install Firebase CLI
   #       run: npm install -g firebase-tools

--- a/README.md
+++ b/README.md
@@ -1,0 +1,8 @@
+# Jam Poker
+
+### Lockfiles
+CI prefers deterministic installs via `npm ci`. If you develop locally, run `npm install` at repo root and in `functions/` to generate/refresh:
+- ./package-lock.json
+- ./functions/package-lock.json
+
+Commit both lockfiles so CI can use `npm ci`. Without them, CI falls back to `npm install`.


### PR DESCRIPTION
## Summary
- configure the deploy workflow to use Node 18 with npm cache and fallback install commands when lockfiles are absent
- update the preview workflow template to match the new Node setup and install logic
- document the preferred lockfile setup in the new README section

## Testing
- not run (workflow updates only)


------
https://chatgpt.com/codex/tasks/task_e_68c88ec2b244832eba53463f978db40b