### PR TITLE
Fix Node cache conditions in CI workflows

### DIFF
--- a/.github/workflows/deploy-on-merge.yml
+++ b/.github/workflows/deploy-on-merge.yml
@@ -20,7 +20,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup Node
+      - name: Setup Node (cache: root + functions)
+        if: ${{ hashFiles('package-lock.json') != '' && hashFiles('functions/package-lock.json') != '' }}
         uses: actions/setup-node@v4
         with:
           node-version: '18'
@@ -28,6 +29,28 @@ jobs:
           cache-dependency-path: |
             package-lock.json
             functions/package-lock.json
+
+      - name: Setup Node (cache: root only)
+        if: ${{ hashFiles('package-lock.json') != '' && hashFiles('functions/package-lock.json') == '' }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'npm'
+          cache-dependency-path: package-lock.json
+
+      - name: Setup Node (cache: functions only)
+        if: ${{ hashFiles('package-lock.json') == '' && hashFiles('functions/package-lock.json') != '' }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'npm'
+          cache-dependency-path: functions/package-lock.json
+
+      - name: Setup Node (no cache)
+        if: ${{ hashFiles('package-lock.json') == '' && hashFiles('functions/package-lock.json') == '' }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
 
       - name: Install deps (root)
         run: |

--- a/.github/workflows/firebase-hosting-preview.yml
+++ b/.github/workflows/firebase-hosting-preview.yml
@@ -23,7 +23,8 @@ jobs:
   #   steps:
   #     - uses: actions/checkout@v4
   #
-  #     - name: Setup Node
+  #     - name: Setup Node (cache: root + functions)
+  #       if: ${{ hashFiles('package-lock.json') != '' && hashFiles('functions/package-lock.json') != '' }}
   #       uses: actions/setup-node@v4
   #       with:
   #         node-version: '18'
@@ -31,6 +32,28 @@ jobs:
   #         cache-dependency-path: |
   #           package-lock.json
   #           functions/package-lock.json
+
+  #     - name: Setup Node (cache: root only)
+  #       if: ${{ hashFiles('package-lock.json') != '' && hashFiles('functions/package-lock.json') == '' }}
+  #       uses: actions/setup-node@v4
+  #       with:
+  #         node-version: '18'
+  #         cache: 'npm'
+  #         cache-dependency-path: package-lock.json
+
+  #     - name: Setup Node (cache: functions only)
+  #       if: ${{ hashFiles('package-lock.json') == '' && hashFiles('functions/package-lock.json') != '' }}
+  #       uses: actions/setup-node@v4
+  #       with:
+  #         node-version: '18'
+  #         cache: 'npm'
+  #         cache-dependency-path: functions/package-lock.json
+
+  #     - name: Setup Node (no cache)
+  #       if: ${{ hashFiles('package-lock.json') == '' && hashFiles('functions/package-lock.json') == '' }}
+  #       uses: actions/setup-node@v4
+  #       with:
+  #         node-version: '18'
 
   #     - name: Install deps (root)
   #       run: |


### PR DESCRIPTION
## Summary
- replace the Node setup step with a conditional caching block so missing lockfiles do not fail the workflow
- keep the npm ci/npm install fallback logic for both root and functions dependencies
- mirror the new setup instructions in the commented firebase preview workflow

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68c8917c9f48832ea35115336f1677b0