### PR TITLE
Add automatic hand dealing and admin auto-deal orchestration

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -83,6 +83,11 @@ service cloud.firestore {
     match /tables/{tableId}/hands/{handId} {
       allow read: if true;
       allow write: if false;
+
+      match /private/{seatId} {
+        allow read: if request.auth != null && request.auth.uid == resource.data.uid;
+        allow write: if false;
+      }
     }
 
     match /tables/{tableId}/hands/{handId}/intents/{intentId} {

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -11,6 +11,7 @@ export { leaveSeatTX } from "./leaveSeatTX";
 export { onHandEndCleanup } from "./handEnd";
 export { pokerCall } from "./pokerCall";
 export { startHand } from "./startHand";
+export { startHandAndDeal } from "./startHandAndDeal";
 
 
 function getTableBlinds(table: any) {

--- a/functions/src/startHandAndDeal.ts
+++ b/functions/src/startHandAndDeal.ts
@@ -1,0 +1,210 @@
+import { onCall, HttpsError } from 'firebase-functions/v2/https';
+import { logger } from 'firebase-functions';
+import { FieldValue } from 'firebase-admin/firestore';
+import { db } from './admin';
+
+type Variant = 'holdem' | 'omaha';
+
+const makeDeck = (): string[] => {
+  const ranks = ['A', 'K', 'Q', 'J', 'T', '9', '8', '7', '6', '5', '4', '3', '2'];
+  const suits = ['s', 'h', 'd', 'c'];
+  const deck: string[] = [];
+  for (const rank of ranks) {
+    for (const suit of suits) deck.push(`${rank}${suit}`);
+  }
+  return deck;
+};
+
+const shuffleInPlace = (deck: string[]) => {
+  for (let i = deck.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [deck[i], deck[j]] = [deck[j], deck[i]];
+  }
+};
+
+const normalizeVariant = (value: unknown): Variant => {
+  return value === 'omaha' ? 'omaha' : 'holdem';
+};
+
+const toSeatNumber = (value: unknown): number | null => {
+  if (typeof value === 'number' && Number.isInteger(value)) return value;
+  if (typeof value === 'string' && /^\d+$/.test(value)) return Number(value);
+  return null;
+};
+
+const toCents = (value: unknown): number => {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  return 0;
+};
+
+export const startHandAndDeal = onCall(async (request) => {
+  const { tableId, variant } = request.data || {};
+  const uid = request.auth?.uid;
+  if (!uid) throw new HttpsError('unauthenticated', 'auth-required');
+  if (!tableId || typeof tableId !== 'string') {
+    throw new HttpsError('invalid-argument', 'missing-table');
+  }
+
+  const normalizedVariant = normalizeVariant(variant);
+
+  const tableRef = db.doc(`tables/${tableId}`);
+  const handRef = db.doc(`tables/${tableId}/handState/current`);
+  const seatsCol = tableRef.collection('seats');
+
+  const result = await db.runTransaction(async (tx) => {
+    const [tableSnap, handSnap, seatsSnap] = await Promise.all([
+      tx.get(tableRef),
+      tx.get(handRef),
+      tx.get(seatsCol),
+    ]);
+
+    if (!tableSnap.exists) {
+      throw new HttpsError('not-found', 'table-not-found');
+    }
+
+    const tableData = tableSnap.data() as Record<string, unknown>;
+    const tableAny = tableData as Record<string, any>;
+    if ((tableAny.createdByUid as string | undefined) !== uid) {
+      throw new HttpsError('permission-denied', 'not-table-admin');
+    }
+
+    const handData = handSnap.data() as Record<string, unknown> | undefined;
+    if (handData?.street) {
+      throw new HttpsError('failed-precondition', 'already-in-hand');
+    }
+
+    const occupiedSeats: Array<{ seatIndex: number; uid: string }> = [];
+    seatsSnap.forEach((docSnap) => {
+      const data = docSnap.data();
+      const seatIndex = toSeatNumber(data?.seatIndex ?? docSnap.id);
+      const seatUid = typeof data?.occupiedBy === 'string' ? data.occupiedBy : null;
+      if (seatIndex != null && seatUid) {
+        occupiedSeats.push({ seatIndex, uid: seatUid });
+      }
+    });
+
+    occupiedSeats.sort((a, b) => a.seatIndex - b.seatIndex);
+    if (occupiedSeats.length < 2) {
+      throw new HttpsError('failed-precondition', 'not-enough-players');
+    }
+
+    const seatOrder = occupiedSeats.map((s) => s.seatIndex);
+    const nextSeat = (arr: number[], current: number) => {
+      const idx = arr.indexOf(current);
+      const nextIdx = (idx + 1) % arr.length;
+      return arr[nextIdx];
+    };
+
+    const previousDealer = toSeatNumber(handData?.dealerSeat);
+    let dealerSeat: number;
+    if (previousDealer != null && seatOrder.includes(previousDealer)) {
+      dealerSeat = nextSeat(seatOrder, previousDealer);
+    } else {
+      dealerSeat = seatOrder[0];
+    }
+
+    const sbSeat = nextSeat(seatOrder, dealerSeat);
+    const bbSeat = nextSeat(seatOrder, sbSeat);
+    const toActSeat = seatOrder.length === 2 ? sbSeat : nextSeat(seatOrder, bbSeat);
+
+    const nextHandNo = (typeof handData?.handNo === 'number' ? handData.handNo : 0) + 1;
+
+    const blinds = (tableAny.blinds as Record<string, any>) || {};
+    const sbCents = toCents(blinds?.sbCents ?? tableAny?.smallBlindCents);
+    const bbCents = toCents(blinds?.bbCents ?? tableAny?.bigBlindCents);
+
+    const commits: Record<string, number> = {
+      [String(sbSeat)]: sbCents,
+      [String(bbSeat)]: bbCents,
+    };
+
+    const potCents = Object.values(commits).reduce((sum, value) => sum + (Number.isFinite(value) ? value : 0), 0);
+
+    const deck = makeDeck();
+    shuffleInPlace(deck);
+
+    const cardsPerSeat = normalizedVariant === 'omaha' ? 4 : 2;
+    const dealingOrder: number[] = [];
+    let cursor = sbSeat;
+    do {
+      dealingOrder.push(cursor);
+      cursor = nextSeat(seatOrder, cursor);
+    } while (cursor !== sbSeat);
+
+    const seatCards = new Map<number, string[]>();
+    dealingOrder.forEach((seat) => seatCards.set(seat, []));
+
+    let deckIndex = 0;
+    for (let round = 0; round < cardsPerSeat; round += 1) {
+      for (const seat of dealingOrder) {
+        const card = deck[deckIndex];
+        deckIndex += 1;
+        if (!card) {
+          throw new HttpsError('internal', 'deck-exhausted');
+        }
+        seatCards.get(seat)!.push(card);
+      }
+    }
+
+    const players = occupiedSeats.map(({ seatIndex, uid: seatUid }) => ({ seat: seatIndex, uid: seatUid }));
+
+    const privateWrites = players.map(({ seat, uid: seatUid }) => {
+      const cards = seatCards.get(seat) ?? [];
+      const privateRef = tableRef
+        .collection('hands')
+        .doc(String(nextHandNo))
+        .collection('private')
+        .doc(String(seat));
+      tx.set(privateRef, {
+        seat,
+        uid: seatUid,
+        cards,
+        createdAt: FieldValue.serverTimestamp(),
+      });
+      return { seat, count: cards.length };
+    });
+
+    tx.set(handRef, {
+      handNo: nextHandNo,
+      variant: normalizedVariant,
+      street: 'preflop',
+      toActSeat,
+      commits,
+      betToMatchCents: bbCents,
+      potCents,
+      community: [],
+      dealerSeat,
+      sbSeat,
+      bbSeat,
+      lastAggressorSeat: null,
+      lastRaiseSizeCents: 0,
+      lastRaiseToCents: 0,
+      createdAt: FieldValue.serverTimestamp(),
+      updatedAt: FieldValue.serverTimestamp(),
+      version: FieldValue.increment(1),
+      lastWriteBy: 'cf:startHandAndDeal',
+    });
+
+    return {
+      handNo: nextHandNo,
+      variant: normalizedVariant,
+      players,
+      privateWrites,
+    };
+  });
+
+  logger.info('deal.start', {
+    tableId,
+    variant: result.variant,
+    handNo: result.handNo,
+    players: result.players,
+  });
+
+  result.privateWrites.forEach((entry) => {
+    logger.info('deal.hole', { tableId, handNo: result.handNo, seat: entry.seat, count: entry.count });
+  });
+
+  logger.info('deal.done', { tableId, handNo: result.handNo });
+
+  return { ok: true, handNo: result.handNo };
+});

--- a/functions/src/takeActionTX.ts
+++ b/functions/src/takeActionTX.ts
@@ -502,7 +502,7 @@ export const takeActionTX = onCall(async (request: CallableRequest<any>) => {
     };
     if (telemetryPayloadForError) {
       console.error('takeActionTX.apply.error', {
-        ...telemetryPayloadForError,
+        ...(telemetryPayloadForError as Record<string, unknown>),
         error: errorPayload,
       });
     } else {

--- a/public/js/autoDeal.js
+++ b/public/js/autoDeal.js
@@ -1,0 +1,150 @@
+import { app } from '/firebase-init.js';
+import { db } from '/common.js';
+import { awaitAuthReady } from '/auth.js';
+import { collection, doc, onSnapshot } from 'https://www.gstatic.com/firebasejs/10.12.5/firebase-firestore.js';
+import { getFunctions, httpsCallable } from 'https://www.gstatic.com/firebasejs/10.12.5/firebase-functions.js';
+
+const TEN_SECONDS = 10000;
+
+const normalizeVariant = (value) => (value === 'omaha' ? 'omaha' : 'holdem');
+
+const countOccupied = (snap) => {
+  let count = 0;
+  snap.forEach((docSnap) => {
+    const data = docSnap.data();
+    if (data && typeof data.occupiedBy === 'string' && data.occupiedBy) count += 1;
+  });
+  return count;
+};
+
+export function initAutoDeal({
+  tableId,
+  initialVariant = 'holdem',
+  onTick,
+} = {}) {
+  if (!tableId) throw new Error('tableId required for auto deal');
+
+  const fns = getFunctions(app);
+  const callable = httpsCallable(fns, 'startHandAndDeal');
+
+  let currentVariant = normalizeVariant(initialVariant);
+  let seatCount = 0;
+  let handActive = false;
+  let timerId = null;
+  let tickerId = null;
+  let targetAt = null;
+  let destroyed = false;
+  let unsubSeats = null;
+  let unsubHand = null;
+
+  const emitTick = (ms) => {
+    if (typeof onTick === 'function') onTick(ms);
+  };
+
+  const clearTimer = () => {
+    if (timerId) {
+      clearTimeout(timerId);
+      timerId = null;
+    }
+    if (tickerId) {
+      clearInterval(tickerId);
+      tickerId = null;
+    }
+    targetAt = null;
+  };
+
+  const cancelCountdown = (logEvent = true) => {
+    if (!timerId && !tickerId) return;
+    clearTimer();
+    emitTick(null);
+    if (logEvent && window.jamlog) window.jamlog.push('auto.deal.canceled', { tableId });
+  };
+
+  const scheduleCountdown = () => {
+    if (timerId || tickerId) return;
+    targetAt = Date.now() + TEN_SECONDS;
+    if (window.jamlog) {
+      window.jamlog.push('auto.deal.scheduled', { tableId, inMs: TEN_SECONDS, variant: currentVariant });
+    }
+    emitTick(TEN_SECONDS);
+    timerId = setTimeout(async () => {
+      clearTimer();
+      emitTick(0);
+      if (!(seatCount >= 2 && !handActive) || destroyed) return;
+      if (window.jamlog) window.jamlog.push('auto.deal.call', { tableId, variant: currentVariant });
+      try {
+        await awaitAuthReady();
+        await callable({ tableId, variant: currentVariant });
+      } catch (err) {
+        console.error('startHandAndDeal failed', err);
+      }
+    }, TEN_SECONDS);
+    tickerId = setInterval(() => {
+      if (!targetAt) return;
+      const remaining = Math.max(0, targetAt - Date.now());
+      emitTick(remaining);
+    }, 250);
+  };
+
+  const evaluate = () => {
+    if (destroyed) return;
+    const eligible = seatCount >= 2 && !handActive;
+    if (eligible) scheduleCountdown();
+    else cancelCountdown();
+  };
+
+  unsubSeats = onSnapshot(
+    collection(db, 'tables', tableId, 'seats'),
+    (snap) => {
+      seatCount = countOccupied(snap);
+      evaluate();
+    },
+    (err) => {
+      console.error('autoDeal seats listener error', err);
+      cancelCountdown(false);
+    },
+  );
+
+  unsubHand = onSnapshot(
+    doc(db, 'tables', tableId, 'handState', 'current'),
+    (snap) => {
+      const data = snap.exists() ? snap.data() : null;
+      const street = data && data.street;
+      handActive = !!street;
+      if (handActive) {
+        cancelCountdown();
+      } else {
+        evaluate();
+      }
+    },
+    (err) => {
+      console.error('autoDeal hand listener error', err);
+      cancelCountdown(false);
+    },
+  );
+
+  const controller = {
+    setVariant(value) {
+      const normalized = normalizeVariant(value);
+      if (normalized === currentVariant) return;
+      currentVariant = normalized;
+      if (timerId || tickerId) {
+        cancelCountdown(true);
+        evaluate();
+      }
+    },
+    destroy() {
+      destroyed = true;
+      cancelCountdown(false);
+      emitTick(null);
+      if (unsubSeats) unsubSeats();
+      if (unsubHand) unsubHand();
+      unsubSeats = null;
+      unsubHand = null;
+    },
+  };
+
+  evaluate();
+
+  return controller;
+}

--- a/public/table.css
+++ b/public/table.css
@@ -39,6 +39,29 @@ body.variant-v1 .community-card.enter {
   align-items: center;
 }
 
+.seat .seat-cards {
+  margin-top: 6px;
+  display: flex;
+  gap: 4px;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.seat .card-chip {
+  min-width: 36px;
+  text-align: center;
+}
+
+.card-back {
+  background: rgba(15, 23, 42, 0.7);
+  border-color: #1e293b;
+}
+
+.card-face {
+  background: rgba(14, 165, 233, 0.2);
+  border-color: #38bdf8;
+}
+
 .seat .pos-badge {
   position: absolute;
   top: -4px;

--- a/public/table.html
+++ b/public/table.html
@@ -51,6 +51,7 @@
     import { startActionWorker } from "/adminWorker.js";
     import { initAdminHud } from "/js/adminHud.js";
     import { startHand } from "/startHand.js";
+    import { initAutoDeal } from "/js/autoDeal.js";
     import { db, dollars, formatCents, renderCurrentPlayerControls, isDebug, setDebug, getCurrentPlayer, formatCard, stageLabel, showSeatsDebug, debugLog } from "/common.js";
     import {
       doc, setDoc, updateDoc, onSnapshot, collection, query, orderBy, serverTimestamp,
@@ -333,9 +334,19 @@
       const tSnap = await getDoc(doc(db, `tables/${tableId}`));
       const createdByUid = tSnap.exists() ? (tSnap.data()?.createdByUid || null) : null;
       const isAdmin = !!(createdByUid && createdByUid === u.uid);
+      isTableAdmin = isAdmin;
       if (isAdmin) {
         document.body.classList.add('is-table-admin');
         const tableSnapData = tSnap.exists() ? (tSnap.data() || null) : null;
+        if (!adminVariantInitialized && tableSnapData) {
+          const storedVariant = typeof tableSnapData.nextVariant === 'string'
+            ? tableSnapData.nextVariant
+            : typeof tableSnapData.nextVariantId === 'string'
+              ? tableSnapData.nextVariantId
+              : null;
+          if (storedVariant) adminVariant = normalizeVariant(storedVariant);
+        }
+        adminVariantInitialized = true;
         const tableName = tableSnapData && typeof tableSnapData.name === 'string' ? tableSnapData.name : null;
         tableHud = initAdminHud({
           page: 'TABLE',
@@ -367,6 +378,11 @@
             tableWorkerUnsub();
             tableWorkerUnsub = null;
           }
+          destroyAutoDeal();
+          if (holeSub) {
+            holeSub();
+            holeSub = null;
+          }
         }, { once: true });
         try {
           const { initAdvanceStreet } = await import('/js/advanceStreet.js');
@@ -379,6 +395,7 @@
       } else {
         if (window.jamlog) window.jamlog.push('worker.skip', { tableId, isAdmin: false });
       }
+      ensureAutoDeal();
     }
     document.body.classList.add('variant-v1');
     if (window.jamlog) window.jamlog.setTableId(tableId || null);
@@ -404,6 +421,11 @@
     let handState = null;
     let seatData = [];
     let mySeatIndex = null;
+    let myHoleCards = [];
+    let holeSub = null;
+    let holeSubSeat = null;
+    let holeSubHandNo = null;
+    let holeDataLoaded = false;
     const foldedSeats = new Set();
     let pending = null;
     let pendingTimer = null;
@@ -413,9 +435,113 @@
     let backfillTimer = null;
     let seatCountTimer = null;
     let seatCountDesync = false;
+    let isTableAdmin = false;
+    let autoDealController = null;
+    let adminVariant = 'holdem';
+    let adminVariantInitialized = false;
+    let autoDealCountdownEl = null;
+    let autoDealVariantSelect = null;
+    let autoDealCountdownMs = null;
     let lastHandStateLogKey = null;
     const tableRef = tableId ? doc(db, 'tables', tableId) : null;
     const handRef = tableId ? doc(db, handDocPath(tableId)) : null;
+
+    const normalizeVariant = (value) => (value === 'omaha' ? 'omaha' : 'holdem');
+
+    function updateAutoDealCountdown(ms) {
+      autoDealCountdownMs = typeof ms === 'number' ? ms : null;
+      if (!autoDealCountdownEl) return;
+      if (autoDealCountdownMs == null) {
+        autoDealCountdownEl.style.display = 'none';
+        autoDealCountdownEl.textContent = '';
+        return;
+      }
+      const seconds = Math.max(0, Math.ceil(autoDealCountdownMs / 1000));
+      autoDealCountdownEl.style.display = '';
+      autoDealCountdownEl.textContent = `Dealing in ${seconds}…`;
+    }
+
+    function ensureAutoDeal() {
+      if (!tableId || !isTableAdmin) {
+        if (autoDealController) {
+          autoDealController.destroy();
+          autoDealController = null;
+        }
+        updateAutoDealCountdown(null);
+        return;
+      }
+      if (!autoDealController) {
+        autoDealController = initAutoDeal({
+          tableId,
+          initialVariant: adminVariant,
+          onTick: updateAutoDealCountdown,
+        });
+      } else {
+        autoDealController.setVariant(adminVariant);
+      }
+    }
+
+    function destroyAutoDeal() {
+      if (autoDealController) {
+        autoDealController.destroy();
+        autoDealController = null;
+      }
+      updateAutoDealCountdown(null);
+    }
+
+    function updateHoleSubscription() {
+      const seat = typeof mySeatIndex === 'number' ? mySeatIndex : null;
+      const handNo = handState && typeof handState.handNo === 'number' ? handState.handNo : null;
+
+      if (!tableId || seat == null || handNo == null) {
+        if (holeSub) {
+          holeSub();
+          holeSub = null;
+        }
+        holeSubSeat = null;
+        holeSubHandNo = null;
+        if (myHoleCards.length || holeDataLoaded) {
+          myHoleCards = [];
+          holeDataLoaded = false;
+          renderSeats();
+        }
+        return;
+      }
+
+      if (holeSub && holeSubSeat === seat && holeSubHandNo === handNo) return;
+
+      if (holeSub) {
+        holeSub();
+        holeSub = null;
+      }
+      holeSubSeat = seat;
+      holeSubHandNo = handNo;
+      myHoleCards = [];
+      holeDataLoaded = false;
+
+      const privateRef = doc(db, 'tables', tableId, 'hands', String(handNo), 'private', String(seat));
+      if (window.jamlog) window.jamlog.push('hole.sub.started', { handNo, seat });
+      holeSub = onSnapshot(privateRef, (snap) => {
+        if (!snap.exists()) {
+          if (myHoleCards.length || holeDataLoaded) {
+            myHoleCards = [];
+            holeDataLoaded = false;
+            renderSeats();
+          }
+          return;
+        }
+        const data = snap.data() || {};
+        const cards = Array.isArray(data.cards)
+          ? data.cards.filter((c) => typeof c === 'string')
+          : [];
+        myHoleCards = cards;
+        holeDataLoaded = true;
+        if (window.jamlog) window.jamlog.push('hole.sub.ok', { count: cards.length });
+        renderSeats();
+      }, (err) => {
+        console.error('hole cards listener error', err);
+      });
+    }
 
     function pushHandStateChanged(state) {
       const payload = buildHandStatePayload(state, seatData);
@@ -468,6 +594,7 @@
               pending = null;
               if (pendingTimer) clearTimeout(pendingTimer);
             }
+            updateHoleSubscription();
             renderSeats();
             renderPlayerBoard();
             if (window.jamlog) {
@@ -483,6 +610,7 @@
               pending = null;
               if (pendingTimer) clearTimeout(pendingTimer);
             }
+            updateHoleSubscription();
             renderSeats();
             renderPlayerBoard();
             noHandBanner.style.display = '';
@@ -535,6 +663,9 @@
               const seatIndex = toSeatNumber(data?.seatIndex ?? d.id);
               return { id: d.id, ...data, seatIndex };
             });
+            const currentPlayer = getCurrentPlayer();
+            mySeatIndex = seatData.find((s) => s.occupiedBy === currentPlayer?.id)?.seatIndex ?? null;
+            updateHoleSubscription();
             showSeatsDebug(tableId, snap.docs);
             renderSeats();
             renderHand();
@@ -594,6 +725,14 @@
       }
     }
 
+    window.addEventListener('beforeunload', () => {
+      destroyAutoDeal();
+      if (holeSub) {
+        holeSub();
+        holeSub = null;
+      }
+    }, { once: true });
+
     function checkSeatCount() {
       if (!tableData) return;
       const derived = seatData.filter(s => s.occupiedBy).length;
@@ -634,7 +773,26 @@
       const activeSeatCount = t.activeSeatCount ?? 0;
       const desyncLine = seatCountDesync ? `<div class="small">Players seated: ${derivedSeatCount} (active: ${activeSeatCount})</div>` : '';
       const probeBtnHtml = isDebug() ? `<button id="btn-rules-probe" class="small" style="margin-left:8px;">Rules Probe</button>` : '';
-      const startBtnHtml = `<div id="start-hand-wrap" style="margin-top:8px;text-align:right;"><button id="btn-start-hand" class="small" data-action="start-hand">Start Hand</button>${probeBtnHtml}<div id="start-hand-hint" class="small" style="margin-top:4px;display:none;"></div></div>`;
+      const autoDealControls = !isTableAdmin ? '' : `
+        <div class="auto-deal-controls" style="display:flex;flex-direction:column;align-items:flex-end;gap:4px;margin-bottom:8px;">
+          <label class="small" style="display:flex;align-items:center;gap:8px;">
+            Dealer’s choice
+            <select id="dealer-choice-select" style="padding:4px 8px;border-radius:8px;border:1px solid #334155;background:#0b1220;color:#e5e7eb;">
+              <option value="holdem"${adminVariant === 'holdem' ? ' selected' : ''}>Hold'em</option>
+              <option value="omaha"${adminVariant === 'omaha' ? ' selected' : ''}>Omaha</option>
+            </select>
+          </label>
+          <div id="auto-deal-countdown" class="small" style="display:none;"></div>
+        </div>`;
+      const startBtnHtml = `
+        <div id="start-hand-wrap" style="margin-top:8px;text-align:right;">
+          ${autoDealControls}
+          <div style="display:flex;justify-content:flex-end;align-items:center;gap:8px;">
+            <button id="btn-start-hand" class="small" data-action="start-hand">Start Hand</button>
+            ${probeBtnHtml}
+          </div>
+          <div id="start-hand-hint" class="small" style="margin-top:4px;display:none;"></div>
+        </div>`;
       infoEl.innerHTML = `
         <h1>${t.name || '(no name)'}</h1>
         <div class="small">Blinds: ${blindStr}</div>
@@ -644,6 +802,18 @@
         ${startBtnHtml}
       `;
       document.getElementById('btn-rules-probe')?.addEventListener('click', () => rulesProbe(tableId));
+      autoDealVariantSelect = document.getElementById('dealer-choice-select');
+      autoDealCountdownEl = document.getElementById('auto-deal-countdown');
+      if (autoDealVariantSelect) {
+        autoDealVariantSelect.value = adminVariant;
+        autoDealVariantSelect.addEventListener('change', (event) => {
+          const nextValue = normalizeVariant(event.target.value);
+          adminVariant = nextValue;
+          if (autoDealController) autoDealController.setVariant(adminVariant);
+        });
+      }
+      if (autoDealController) autoDealController.setVariant(adminVariant);
+      if (autoDealCountdownEl) updateAutoDealCountdown(autoDealCountdownMs);
         const startBtn = document.getElementById('btn-start-hand');
         const hintEl = document.getElementById('start-hand-hint');
         startBtn.disabled = true;
@@ -740,6 +910,24 @@
         } else {
           seatEl.innerHTML = '<div class="small">Sit here</div>';
           seatEl.addEventListener('click', () => claimSeat(i));
+        }
+        if (seat && seat.occupiedBy && handState && handState.street) {
+          const variant = normalizeVariant(handState.variant);
+          const cardsPerSeat = variant === 'omaha' ? 4 : 2;
+          const cardsWrapper = document.createElement('div');
+          cardsWrapper.className = 'seat-cards';
+          let cardsHtml = '';
+          if (seat.seatIndex === mySeatIndex) {
+            if (myHoleCards.length > 0) {
+              cardsHtml = myHoleCards.map((card) => `<span class="card-chip card-face">${formatCard(card)}</span>`).join(' ');
+            } else {
+              cardsHtml = new Array(cardsPerSeat).fill('<span class="card-chip card-back">🂠</span>').join(' ');
+            }
+          } else {
+            cardsHtml = new Array(cardsPerSeat).fill('<span class="card-chip card-back">🂠</span>').join(' ');
+          }
+          cardsWrapper.innerHTML = cardsHtml;
+          seatEl.appendChild(cardsWrapper);
         }
         if (handState) {
           if (i === handState.dealerSeat) {
@@ -880,6 +1068,7 @@
       function renderPlayerBoard() {
         const current = getCurrentPlayer();
         mySeatIndex = seatData.find(s => s.occupiedBy === current?.id)?.seatIndex ?? null;
+        updateHoleSubscription();
         if (!current || mySeatIndex == null) { boardEl.style.display = 'none'; return; }
         const snapshotForLog = buildHandStatePayload(handState, seatData);
         const derived = deriveHandContext(snapshotForLog);


### PR DESCRIPTION
## Summary
- add a startHandAndDeal callable that validates table admins, seeds a shuffled deck, writes private hole-card docs, and logs deal telemetry
- restrict Firestore access to private hand docs, adjust takeAction telemetry typing, and export the new function
- add a client auto-deal module with admin dealer-choice controls, countdown UX, and seat rendering that subscribes to my hole cards

## Testing
- npm run build (functions)


------
https://chatgpt.com/codex/tasks/task_e_68c89fa009cc832eb85f1d920ea73df8