### PR TITLE
Secure Firestore rules and add wipe workflow

### DIFF
--- a/.github/workflows/wipe-firestore.yml
+++ b/.github/workflows/wipe-firestore.yml
@@ -1,0 +1,55 @@
+name: Wipe Firestore (prod)
+
+on:
+  workflow_dispatch:
+    inputs:
+      confirm:
+        description: "Type WIPE to confirm deleting Firestore collections in jam-poker"
+        required: true
+        default: "WIPE"
+
+jobs:
+  wipe:
+    if: ${{ github.event.inputs.confirm == 'WIPE' }}
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+
+      - name: Write service account key
+        # Add a GitHub Secret named FIREBASE_SERVICE_ACCOUNT (full JSON)
+        run: |
+          echo "${FIREBASE_SERVICE_ACCOUNT}" > "$HOME/gcp-key.json"
+          echo "GOOGLE_APPLICATION_CREDENTIALS=$HOME/gcp-key.json" >> $GITHUB_ENV
+        env:
+          FIREBASE_SERVICE_ACCOUNT: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
+
+      - name: Install firebase-tools
+        run: npm i -g firebase-tools@14.16.0
+
+      - name: Show firebase-tools version
+        run: firebase --version
+
+      - name: Set project
+        run: firebase use jam-poker --project jam-poker
+
+      - name: Wipe Firestore collections (recursive)
+        run: |
+          set -euo pipefail
+          # Add/remove collections as needed
+          TARGETS=(players tables actions handState logs)
+          for COL in "${TARGETS[@]}"; do
+            echo "Deleting collection: $COL"
+            firebase firestore:delete -y -r "$COL" --project jam-poker || true
+          done
+          echo "Done."
+

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,9 +1,77 @@
 rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
-    match /{doc=**} {
-      allow read: false;
-      allow write: false;
+
+    function isSignedIn() {
+      return request.auth != null;
+    }
+
+    // Short-term dev backstop so you don't get locked out.
+    function isDevAdmin() {
+      return isSignedIn() && request.auth.uid in [
+        "qluorW7OtXddS2WZnGPxG0R7HDk1" // YOU (owner)
+      ];
+    }
+
+    // Preferred: set custom claim { admin: true } on your user.
+    function isAdmin() {
+      return isSignedIn() && (request.auth.token.admin == true || isDevAdmin());
+    }
+
+    function isRegisteredPlayer() {
+      return isSignedIn()
+        && exists(/databases/$(database)/documents/players/$(request.auth.uid));
+    }
+
+    // Players registry
+    match /players/{playerId} {
+      allow read: if isSignedIn();
+      allow create, update, delete: if isAdmin();
+    }
+
+    // Tables and subcollections
+    match /tables/{tableId} {
+      allow read: if isSignedIn();
+      allow create, update, delete: if isAdmin();
+
+      // seats/{seatIndex}
+      match /seats/{seatId} {
+        allow read: if isSignedIn();
+
+        // player can take a seat only if registered; can only claim as self
+        allow update: if isRegisteredPlayer()
+          && request.resource.data.uid == request.auth.uid
+          && (resource.data.uid == null || resource.data.uid == request.auth.uid);
+
+        // admin can fix/clear
+        allow create, delete: if isAdmin();
+      }
+
+      // actions/{actionId}
+      match /actions/{actionId} {
+        allow read: if isSignedIn();
+
+        // player may enqueue their own action for their current seat
+        allow create: if isRegisteredPlayer()
+          && request.resource.data.actorUid == request.auth.uid
+          && request.resource.data.seat is int
+          && exists(/databases/$(database)/documents/tables/$(tableId)/seats/$(request.resource.data.seat))
+          && get(/databases/$(database)/documents/tables/$(tableId)/seats/$(request.resource.data.seat)).data.uid == request.auth.uid;
+
+        // only admin edits/deletes after creation
+        allow update, delete: if isAdmin();
+      }
+
+      // handState/*
+      match /handState/{docId} {
+        allow read: if isSignedIn();
+        allow write: if false; // server-only
+      }
+    }
+
+    // Default deny
+    match /{document=**} {
+      allow read, write: if false;
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "test": "tsx tests/**/*.spec.ts"
+    "test": "tsx tests/**/*.spec.ts",
+    "wipe:prod": "firebase firestore:delete -y -r players tables actions handState logs --project jam-poker"
   },
   "devDependencies": {
     "firebase-tools": "^13.26.0",


### PR DESCRIPTION
## Summary
- harden Firestore security rules to restrict writes to admins while allowing authenticated reads
- add a manual GitHub Action that wipes key Firestore collections using a service account
- expose an npm script to run the same wipe command locally

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68c8dd05aaec832ea1de816d4b6d4bd2